### PR TITLE
Add tag visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The source code for quickly creating visualizations of state machines and statec
 ### npm start
 
 Runs the app in the development mode.
-Open http://localhost:8080 to view it in the browser.
+Open http://localhost:3000 to view it in the browser.
 
 The page will reload if you make edits.
 You will also see any lint errors in the console.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "@xstate/graph": "^1.3.0",
-    "@xstate/react": "^1.3.2",
+    "@xstate/react": "^1.3.4",
     "elkjs": "^0.7.1",
     "framer-motion": "^4",
     "monaco-editor": "^0.24.0",
@@ -22,7 +22,7 @@
     "react-scripts": "4.0.3",
     "web-vitals": "^1.0.1",
     "web-worker": "^1.0.0",
-    "xstate": "^4.19.1"
+    "xstate": "^4.20.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/StateNodeViz.scss
+++ b/src/StateNodeViz.scss
@@ -53,8 +53,17 @@
 
 [data-viz='stateNode-header'] {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto 1fr auto;
+  grid-template-areas: 'type key tags';
   align-items: center;
+
+  > [data-viz='stateNode-key'] {
+    grid-area: key;
+  }
+
+  > [data-viz='stateNode-tags'] {
+    grid-area: tags;
+  }
 }
 
 [data-viz='stateNode-content'] {
@@ -117,4 +126,22 @@
 
 [data-viz='stateNode-invocations'] {
   padding: 0.5rem;
+}
+
+[data-viz='stateNode-tags'] {
+  text-overflow: ellipsis;
+  padding: 0.5rem;
+}
+
+[data-viz='stateNode-tag'] {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: bold;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+  background-color: #fff5;
+
+  & + & {
+    margin-left: 1ch;
+  }
 }

--- a/src/StateNodeViz.tsx
+++ b/src/StateNodeViz.tsx
@@ -118,6 +118,15 @@ export const StateNodeViz: React.FC<{
               ></div>
             )}
             <div data-viz="stateNode-key">{stateNode.key}</div>
+            <div data-viz="stateNode-tags">
+              {stateNode.tags.map((tag, i) => {
+                return (
+                  <div data-viz="stateNode-tag" key={i}>
+                    {tag}
+                  </div>
+                );
+              })}
+            </div>
           </div>
           {stateNode.definition.invoke.length > 0 && (
             <div data-viz="stateNode-invocations">

--- a/src/testMachine.ts
+++ b/src/testMachine.ts
@@ -52,6 +52,7 @@ export const testMachine = createMachine<{ count: number }>({
   },
   states: {
     simple: {
+      tags: ['tag1', 'tag2'],
       entry: ['action1', 'really long action', 'action3'],
       exit: ['anotherAction', 'action4'],
       invoke: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2860,10 +2860,10 @@
   resolved "https://registry.yarnpkg.com/@xstate/graph/-/graph-1.3.0.tgz#710a7f24a86c81ff27d6cc6766102a15f3b23f7b"
   integrity sha512-/gPDHcXvNm+DY0Cw+wHVza+6eebmqji6u5rEYKOIAUWuAFBn7svVY6VxtRnWnjGl9B3rHTioenV0ELH8GzK3eA==
 
-"@xstate/react@^1.3.2":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@xstate/react/-/react-1.3.3.tgz#5faf7604b8076d06883348f93b241c38ed0e71f6"
-  integrity sha512-10QfCZr3dxahYmpykQ5iGtzjtKJ5dkiu1P4JyD0dGnmQLbBD6XDKCnzfOe5MWD8CocErgsaEMmsTMVsnxIAuYQ==
+"@xstate/react@^1.3.4":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@xstate/react/-/react-1.3.4.tgz#d79126c9eecc9a1225d553e3421aaad68eb5ee5e"
+  integrity sha512-uKbKriFYjgeqMeEAqOv8IWRM8WBx5i/4pMPGpqo58wd7sInhFmmK6HWfV7eX3nD/vJPfxWielNMxAUCUdVh1pA==
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
     use-subscription "^1.3.0"
@@ -12483,10 +12483,10 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xstate@^4.19.1:
-  version "4.19.1"
-  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.19.1.tgz#6d6b5388b11a0297894be0caaef2299891c6fb6a"
-  integrity sha512-tnBh6ue9MiyoMkE2+w1IqfvJm4nBe3S4Ky/RLvlo9vka8FdO4WyyT3M7PA0pQoM/FZ9aJVWFOlsNw0Nc7E+4Bw==
+xstate@^4.20.0:
+  version "4.20.0"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.20.0.tgz#6f241f2b49c840cb6e05b32544a6048362f558e2"
+  integrity sha512-u5Ou1CMo/oWApasmv1TYTHgj38k69DJdTqQdBBwt+/ooNhPJQiSIKTB3Y3HvX0h5tulwfSo6xAwZgBgjRsK3LA==
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
This PR adds visualization for state node tags:

![CleanShot 2021-06-14 at 09 53 31](https://user-images.githubusercontent.com/1093738/121903820-acea7600-ccf6-11eb-8cc6-33dd9238d5e1.png)
