### PR TITLE
Refactor canvas control buttons

### DIFF
--- a/src/CanvasContainer.tsx
+++ b/src/CanvasContainer.tsx
@@ -1,16 +1,10 @@
-import { useMachine } from '@xstate/react';
-import React, { useContext } from 'react';
-import { ButtonGroup, IconButton, ChakraProvider } from '@chakra-ui/react';
-import { AddIcon, MinusIcon, RepeatIcon } from '@chakra-ui/icons';
+import React from 'react';
 
-import { canvasMachine, canvasModel } from './canvasMachine';
-import { theme } from './theme';
-import { SimulationContext } from './SimulationContext';
+import { canvasModel } from './canvasMachine';
+import { useCanvas } from './useCanvas';
 
 export const CanvasContainer: React.FC = ({ children }) => {
-  const [state, send] = useMachine(canvasMachine);
-  const simService = useContext(SimulationContext);
-
+  const [state, send] = useCanvas();
   return (
     <div
       data-panel="viz"
@@ -25,27 +19,6 @@ export const CanvasContainer: React.FC = ({ children }) => {
       >
         {children}
       </div>
-      <ChakraProvider theme={theme}>
-        <ButtonGroup size="sm" isAttached>
-          <IconButton
-            aria-label="Zoom out"
-            icon={<MinusIcon />}
-            onClick={() => send('ZOOM.OUT')}
-          />
-
-          <IconButton
-            aria-label="Zoom in"
-            icon={<AddIcon />}
-            onClick={() => send('ZOOM.IN')}
-          />
-        </ButtonGroup>
-
-        <IconButton
-          aria-label="Reset"
-          icon={<RepeatIcon />}
-          onClick={() => simService.send('MACHINES.RESET')}
-        />
-      </ChakraProvider>
     </div>
   );
 };

--- a/src/CanvasContext.tsx
+++ b/src/CanvasContext.tsx
@@ -1,0 +1,6 @@
+import { createContext } from 'react';
+import { State, Interpreter } from 'xstate';
+
+export const CanvasContext = createContext<
+  [State<any, any, any>, Interpreter<any, any, any>['send']]
+>(null as any);

--- a/src/CanvasPanel.tsx
+++ b/src/CanvasPanel.tsx
@@ -1,14 +1,52 @@
 import { DirectedGraphNode } from './directedGraph';
-import * as React from 'react';
+import React from 'react';
 import { CanvasContainer } from './CanvasContainer';
 import { Graph } from './Graph';
+import { useMachine } from '@xstate/react';
+import { canvasMachine } from './canvasMachine';
+import { MinusIcon, AddIcon, RepeatIcon } from '@chakra-ui/icons';
+import { ChakraProvider, ButtonGroup, IconButton, Box } from '@chakra-ui/react';
+import { theme } from './theme';
+
+import { CanvasContext } from './CanvasContext';
+import { useSimulation } from './useSimulation';
 
 export const CanvasPanel: React.FC<{ digraph: DirectedGraphNode }> = ({
   digraph,
 }) => {
+  const [state, send] = useMachine(canvasMachine);
+  const simService = useSimulation();
   return (
-    <CanvasContainer>
-      <Graph digraph={digraph} />
-    </CanvasContainer>
+    <Box>
+      <CanvasContext.Provider value={[state, send]}>
+        <Box zIndex={1} bg="black">
+          <ChakraProvider theme={theme}>
+            <ButtonGroup size="sm" spacing={2} padding={2}>
+              <IconButton
+                aria-label="Zoom out"
+                title="Zoom out"
+                icon={<MinusIcon />}
+                onClick={() => send('ZOOM.OUT')}
+              />
+              <IconButton
+                aria-label="Zoom in"
+                title="Zoom in"
+                icon={<AddIcon />}
+                onClick={() => send('ZOOM.IN')}
+              />
+              <IconButton
+                aria-label="Reset"
+                title="Reset"
+                icon={<RepeatIcon />}
+                onClick={() => simService.send('MACHINES.RESET')}
+              />
+            </ButtonGroup>
+          </ChakraProvider>
+        </Box>
+        <CanvasContainer>
+          <Graph digraph={digraph} />
+        </CanvasContainer>
+      </CanvasContext.Provider>
+    </Box>
   );
 };

--- a/src/EdgeViz.tsx
+++ b/src/EdgeViz.tsx
@@ -1,11 +1,11 @@
 import { useSelector } from '@xstate/react';
-import React, { useContext } from 'react';
-import { SimulationContext } from './SimulationContext';
+import React from 'react';
 import { useGetRect } from './getRect';
 import { getPath, LPathParam, pathToD, Point, SvgPath } from './pathUtils';
 import './EdgeViz.scss';
 import { ArrowMarker } from './ArrowMarker';
 import { DirectedGraphEdge } from './directedGraph';
+import { useSimulation } from './useSimulation';
 
 function translatePoint(point: Point, vector: Point): Point {
   return {
@@ -31,7 +31,7 @@ export const EdgeViz: React.FC<{ edge: DirectedGraphEdge; order: number }> = ({
   edge,
   order,
 }) => {
-  const service = useContext(SimulationContext);
+  const service = useSimulation();
   const isActive = useSelector(service, (state) => {
     return state.context.state.configuration.includes(edge.source);
   });

--- a/src/EventsPanel.tsx
+++ b/src/EventsPanel.tsx
@@ -1,9 +1,9 @@
 import { useService } from '@xstate/react';
-import React, { useContext } from 'react';
-import { SimulationContext } from './SimulationContext';
+import React from 'react';
+import { useSimulation } from './useSimulation';
 
 export const EventsPanel: React.FC = () => {
-  const [state] = useService(useContext(SimulationContext));
+  const [state] = useService(useSimulation());
 
   return (
     <div>

--- a/src/StateNodeViz.tsx
+++ b/src/StateNodeViz.tsx
@@ -1,11 +1,12 @@
-import React, { useContext, useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import type { StateNode } from 'xstate';
 import './StateNodeViz.scss';
 import './InvokeViz.scss';
 import './ActionViz.scss';
-import { SimulationContext } from './SimulationContext';
+
 import { useService } from '@xstate/react';
 import { deleteRect, setRect } from './getRect';
+import { useSimulation } from './useSimulation';
 
 interface BaseStateNodeDef {
   key: string;
@@ -46,7 +47,7 @@ export const StateNodeViz: React.FC<{
   stateNode: StateNode;
   parent?: StateNodeDef;
 }> = ({ stateNode, parent }) => {
-  const service = useContext(SimulationContext);
+  const service = useSimulation();
   const [state] = useService(service);
   const ref = useRef<HTMLDivElement>(null);
 

--- a/src/StatePanel.tsx
+++ b/src/StatePanel.tsx
@@ -1,11 +1,11 @@
-import React, { useCallback, useContext } from 'react';
-import { SimulationContext } from './SimulationContext';
+import React from 'react';
 import ReactJson from 'react-json-view';
-import { useSelector, useService } from '@xstate/react';
+import { useSelector } from '@xstate/react';
+import { useSimulation } from './useSimulation';
 
 const selectState = (state: any) => state.context.state;
 export const StatePanel: React.FC = () => {
-  const state = useSelector(useContext(SimulationContext), selectState);
+  const state = useSelector(useSimulation(), selectState);
 
   return (
     <div>

--- a/src/TransitionViz.tsx
+++ b/src/TransitionViz.tsx
@@ -1,12 +1,12 @@
 import { useSelector } from '@xstate/react';
-import React, { useContext, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import type { Guard } from 'xstate';
-import { SimulationContext } from './SimulationContext';
 import { DirectedGraphEdge } from './directedGraph';
 import { EventTypeViz } from './EventTypeViz';
 import { deleteRect, setRect } from './getRect';
 import { Point } from './pathUtils';
 import './TransitionViz.scss';
+import { useSimulation } from './useSimulation';
 
 const getGuardType = (guard: Guard<any, any>) => {
   return guard.name; // v4
@@ -18,7 +18,7 @@ export const TransitionViz: React.FC<{
   index: number;
 }> = ({ edge, index, position }) => {
   const definition = edge.transition;
-  const service = useContext(SimulationContext);
+  const service = useSimulation();
   const state = useSelector(service, (s) => s.context.state);
 
   const ref = useRef<any>(null);

--- a/src/useCanvas.tsx
+++ b/src/useCanvas.tsx
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { CanvasContext } from './CanvasContext';
+
+export const useCanvas = () => {
+  const canvas = useContext(CanvasContext);
+  if (canvas === undefined) {
+    throw Error('CanvasContext must be used inside CanvasContext.Provider');
+  }
+  return canvas;
+};

--- a/src/useSimulation.tsx
+++ b/src/useSimulation.tsx
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { SimulationContext } from './SimulationContext';
+
+export const useSimulation = () => {
+  const sim = useContext(SimulationContext);
+  if (sim === undefined) {
+    throw Error(
+      'SimulationContext must be used inside SimulationContext.Provider',
+    );
+  }
+  return sim;
+};


### PR DESCRIPTION
- use custom access hooks over the context: `useSimulation` and `useCanvas`
- move canvas control buttons into a separate header for layout improvement
- adds title attribute to control buttons

![image](https://user-images.githubusercontent.com/8332043/122298952-0b397380-cf06-11eb-88b4-ecee03722c10.png)
