### PR TITLE
Show transition actions

### DIFF
--- a/src/ActionViz.scss
+++ b/src/ActionViz.scss
@@ -1,4 +1,33 @@
+[data-viz='transition-actions'] {
+  background-color: var(--viz-color-bg);
+  padding: 0.5rem;
+
+  &:empty {
+    display: none;
+  }
+}
+
 [data-viz='action'] {
-  // color: black;
   color: var(--viz-color-fg);
+  display: flex;
+  flex-direction: row;
+  gap: 1ch;
+  align-items: baseline;
+  justify-content: flex-start;
+
+  &[data-viz-action] {
+    &:before {
+      content: attr(data-viz-action) ' / ';
+      font-size: var(--viz-font-size-sm);
+      text-transform: uppercase;
+      font-weight: bold;
+      opacity: 0.5;
+      display: inline-block;
+      white-space: nowrap;
+    }
+  }
+}
+
+[data-viz='action-text'] {
+  display: inline-block;
 }

--- a/src/StateNodeViz.scss
+++ b/src/StateNodeViz.scss
@@ -115,13 +115,6 @@
   &:empty {
     display: none;
   }
-  &:before {
-    content: attr(data-viz-actions) ' /';
-    font-size: var(--viz-font-size-sm);
-    text-transform: uppercase;
-    font-weight: bold;
-    opacity: 0.5;
-  }
 }
 
 [data-viz='stateNode-invocations'] {

--- a/src/TransitionViz.scss
+++ b/src/TransitionViz.scss
@@ -10,9 +10,16 @@
 
 [data-viz='transition'] {
   --viz-transition-color: gray;
+  display: inline-flex;
+  flex-direction: row;
+  gap: 0.5rem;
 
   &[data-viz-potential] {
     --viz-transition-color: var(--viz-color-active);
+  }
+
+  > [data-viz='transition-label'] {
+    align-self: center;
   }
 }
 

--- a/src/TransitionViz.tsx
+++ b/src/TransitionViz.tsx
@@ -49,10 +49,10 @@ export const TransitionViz: React.FC<{
         position: 'absolute',
         ...(position && { left: `${position.x}px`, top: `${position.y}px` }),
       }}
+      ref={ref}
     >
       <button
         data-viz="transition-label"
-        ref={ref}
         onMouseEnter={() => {
           service.send({
             type: 'EVENT.PREVIEW',
@@ -83,6 +83,17 @@ export const TransitionViz: React.FC<{
           </span>
         )}
       </button>
+      {definition.actions.length > 0 && (
+        <div data-viz="transition-actions">
+          {definition.actions.map((action) => {
+            return (
+              <div data-viz="action" data-viz-action="do" key={action.type}>
+                <span data-viz="action-text">{action.type}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/notificationMachine.ts
+++ b/src/notificationMachine.ts
@@ -4,13 +4,17 @@ import { createModel } from 'xstate/lib/model';
 
 const toast = createStandaloneToast();
 
-const notifModel = createModel(undefined, {
-  events: {
-    ERROR: (message: string) => ({ message }),
+const notifModel = createModel(
+  {},
+  {
+    events: {
+      ERROR: (message: string) => ({ message }),
+    },
   },
-});
+);
 export const notifMachine = createMachine<typeof notifModel>({
   initial: 'running',
+  context: {},
   on: {
     ERROR: {
       actions: [

--- a/src/testMachine.ts
+++ b/src/testMachine.ts
@@ -1,4 +1,4 @@
-import { createMachine } from 'xstate';
+import { assign, createMachine } from 'xstate';
 
 export const testInvokedMachine = createMachine({
   id: 'm',
@@ -70,6 +70,13 @@ export const testMachine = createMachine<{ count: number }>({
         ],
         EVENT: {
           target: 'final',
+          actions: [
+            'string action',
+            function namedFnAction() {
+              /* ... */
+            },
+            assign({ count: 0 }),
+          ],
           cond: function somethingIsTrue() {
             return true;
           },


### PR DESCRIPTION
This PR shows transition actions, which were previously omitted for no good reason. It also aligns the `data-viz-action` attributes inline with each action, which saves on real-estate and makes it clearer what categories of actions there are (entry, exit, or "do" actions), and it will align with the visual editor.

![CleanShot 2021-06-27 at 19 59 42](https://user-images.githubusercontent.com/1093738/123563437-988c8b80-d782-11eb-993e-48300faa2cb9.png)
![CleanShot 2021-06-27 at 19 59 36](https://user-images.githubusercontent.com/1093738/123563440-9a564f00-d782-11eb-9196-678215c27cfe.png)
