### PR TITLE
Separate sections for `state.value` and `state.context`

### DIFF
--- a/src/StatePanel.tsx
+++ b/src/StatePanel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactJson from 'react-json-view';
 import { useSelector } from '@xstate/react';
-import { State, StateFrom } from 'xstate';
+import { StateFrom } from 'xstate';
 import {
   Accordion,
   AccordionItem,
@@ -12,6 +12,18 @@ import {
 import { useSimulation } from './SimulationContext';
 import { createSimulationMachine } from './simulationMachine';
 
+const JSONView: React.FC<{ src: object; name: string }> = ({ src, name }) => (
+  <ReactJson
+    src={src}
+    name={name}
+    theme="monokai"
+    collapsed={1}
+    onEdit={false}
+    displayDataTypes={false}
+    displayObjectSize={false}
+  />
+);
+
 const selectState = (
   state: StateFrom<ReturnType<typeof createSimulationMachine>>,
 ) =>
@@ -20,15 +32,17 @@ const selectState = (
     : undefined; // TODO: select() method on model
 
 const ActorState: React.FC<{ state: any }> = ({ state }) => {
+  const value = state?.value;
+  const context = state?.context;
   return (
-    <ReactJson
-      src={state}
-      theme="monokai"
-      collapsed={1}
-      onEdit={false}
-      displayDataTypes={false}
-      displayObjectSize={false}
-    />
+    <>
+      <JSONView
+        src={typeof value === 'string' ? { _: value } : value}
+        name="Value"
+      />
+      <JSONView src={context} name="Context" />
+      <JSONView src={state} name="State" />
+    </>
   );
 };
 


### PR DESCRIPTION
This PR adds separate sections for both `state.value` and `state.context` because, from personal experience, those are the two properties you mostly look for in a state while debugging.
closes https://linear.app/statelyai/issue/STA-90/faster-visual-feedback-in-states-panel

![image](https://user-images.githubusercontent.com/8332043/124078544-a5de9a00-da50-11eb-8a91-c5484c7d5775.png)
