### PR TITLE
Fixed an issue with Monaco tooltips being cut off due to overflow hidden on the TabPanels

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,7 +94,7 @@ function App() {
                   <Tab>Actors</Tab>
                 </TabList>
 
-                <TabPanels overflow="hidden">
+                <TabPanels minHeight={0}>
                   <TabPanel padding={0} height="100%">
                     {sourceState.matches({
                       with_source: 'loading_content',

--- a/src/EditorWithXStateImports.tsx
+++ b/src/EditorWithXStateImports.tsx
@@ -17,7 +17,7 @@ export const EditorWithXStateImports = (
       {({ css }) => (
         <Editor
           wrapperClassName={css`
-            overflow: hidden;
+            min-height: 0;
           `}
           defaultPath="main.ts"
           defaultLanguage="typescript"


### PR DESCRIPTION
While reviewing @davidkpiano's PR [here](https://github.com/statelyai/xstate-viz/pull/39), I've noticed that I could easily~ reach a situation like this:
<img width="430" alt="Screenshot 2021-07-14 at 14 14 22" src="https://user-images.githubusercontent.com/9800850/125626204-a6b10484-f2f9-4b77-b9cf-47460cc16f86.png">

It seems that those tooltips are not positioned with fixed positioning and thus the `overflow: hidden;` on the whole container has been cutting the tooltip off.

The additional `overflow: hidden;` applied for one of the Monaco wrapper's (recently added by me to overcome resizing issues) was causing the same issue. So I've played around and I've come up with this fix and now it renders OK and the resizing issue also didn't come back:
<img width="477" alt="Screenshot 2021-07-14 at 14 14 34" src="https://user-images.githubusercontent.com/9800850/125626832-3f977108-4ec9-429d-a69d-cd88041c8b32.png">
