### PR TITLE
Forward props given to the ResizableBox

### DIFF
--- a/src/ResizableBox.tsx
+++ b/src/ResizableBox.tsx
@@ -104,16 +104,15 @@ const ResizeHandle: React.FC<{
   );
 };
 
-export const ResizableBox: React.FC<React.ComponentProps<typeof Box>> = ({
-  gridArea,
-  children,
-}) => {
+export const ResizableBox: React.FC<
+  Omit<React.ComponentProps<typeof Box>, 'width'>
+> = ({ children, ...props }) => {
   const [widthDelta, setWidthDelta] = useState(0);
 
   return (
     <Box
       width={`min(90vw, calc(25rem + max(0px, ${widthDelta}px)))`}
-      gridArea={gridArea}
+      {...props}
     >
       {children}
       <ResizeHandle onChange={(value) => setWidthDelta(value)} />


### PR DESCRIPTION
Since the `ResizableBox` accepts *all* `BoxProps` at the type level it makes sense to forward them to the inner `Box`. Otherwise, the consumer gets tricked - because a lot of props are supposedly accepted but they are actually "swallowed" in practice