### PR TITLE
Make increment of +/- buttons bigger

### DIFF
--- a/src/canvasMachine.tsx
+++ b/src/canvasMachine.tsx
@@ -25,11 +25,11 @@ export const canvasMachine = createMachine<typeof canvasModel>({
   context: canvasModel.initialContext,
   on: {
     'ZOOM.OUT': {
-      actions: canvasModel.assign({ zoom: (ctx) => ctx.zoom * 0.8 }),
+      actions: canvasModel.assign({ zoom: (ctx) => ctx.zoom * 0.85 }),
       cond: (ctx) => ctx.zoom > 0.5,
     },
     'ZOOM.IN': {
-      actions: canvasModel.assign({ zoom: (ctx) => ctx.zoom * 1.2 }),
+      actions: canvasModel.assign({ zoom: (ctx) => ctx.zoom * 1.15 }),
     },
     PAN: {
       actions: canvasModel.assign({


### PR DESCRIPTION
This makes the increment proportional to the amount you're zoomed in, meaning it'll stay in proportion no matter how far in/out you are.

Fixes #67