### PR TITLE
Implement onError for when we can't fetch the user's details

### DIFF
--- a/src/authMachine.ts
+++ b/src/authMachine.ts
@@ -20,7 +20,7 @@ import {
   GetLoggedInUserDataQuery,
   LoggedInUserFragment,
 } from './graphql/GetLoggedInUserData.generated';
-import { notifMachine } from './notificationMachine';
+import { notifMachine, notifModel } from './notificationMachine';
 import {
   makeSourceMachine,
   SourceMachineActorRef,
@@ -182,6 +182,20 @@ export const authMachine = createMachine<typeof authModel>(
                     },
                     {
                       to: (ctx) => ctx.sourceRef!,
+                    },
+                  ),
+                ],
+              },
+              onError: {
+                target: 'idle',
+                actions: [
+                  send(
+                    notifModel.events.BROADCAST(
+                      `Could not load your user's details. Some things may not work as expected. Reload the page to retry.`,
+                      'error',
+                    ),
+                    {
+                      to: (ctx) => ctx.notifRef,
                     },
                   ),
                 ],


### PR DESCRIPTION
This is a pretty lazy implementation, and a bit of a cop-out. But if this happens, we're either really screwed (we'll be getting error reports in Sentry) or the user is on no network, meaning that most system functions won't work anyway.

This is not a finished error handling! We can revisit this later.