### PR TITLE
Set pointer capture on e.target to keep `onClick`s working

### DIFF
--- a/src/CanvasContainer.tsx
+++ b/src/CanvasContainer.tsx
@@ -176,7 +176,8 @@ export const CanvasContainer: React.FC = ({ children }) => {
         }
       }}
       onPointerDown={(e) => {
-        e.currentTarget.setPointerCapture(e.pointerId);
+        // TODO: better typing
+        (e.target as any).setPointerCapture(e.pointerId);
         send({ type: 'GRAB', point: { x: e.pageX, y: e.pageY } });
       }}
       onPointerMove={(e) => {


### PR DESCRIPTION
Solution based on: https://github.com/GoogleChromeLabs/pointer-tracker/issues/4#issuecomment-593929716