### PR TITLE
Fixed overzealous buttons

### DIFF
--- a/src/CanvasContainer.tsx
+++ b/src/CanvasContainer.tsx
@@ -176,15 +176,20 @@ export const CanvasContainer: React.FC = ({ children }) => {
         }
       }}
       onPointerDown={(e) => {
-        // TODO: better typing
-        (e.target as any).setPointerCapture(e.pointerId);
-        send({ type: 'GRAB', point: { x: e.pageX, y: e.pageY } });
+        if (state.nextEvents.includes('GRAB')) {
+          e.currentTarget.setPointerCapture(e.pointerId);
+          send({ type: 'GRAB', point: { x: e.pageX, y: e.pageY } });
+        }
       }}
       onPointerMove={(e) => {
-        send({ type: 'DRAG', point: { x: e.pageX, y: e.pageY } });
+        if (state.nextEvents.includes('DRAG')) {
+          send({ type: 'DRAG', point: { x: e.pageX, y: e.pageY } });
+        }
       }}
       onPointerUp={() => {
-        send('UNGRAB');
+        if (state.nextEvents.includes('UNGRAB')) {
+          send('UNGRAB');
+        }
       }}
     >
       {children}


### PR DESCRIPTION
It's a follow up to https://github.com/statelyai/xstate-viz/pull/114

The problem is that if we capture pointer events on the target then all future pointer events will be, well, captured until we release the pointer. This "breaks" (just a little bit!) the native behavior of buttons. If we press the button, move away and release outside of it the button should not be clicked but because of the pointer capturing it gets clicked.

https://www.loom.com/share/a81639611dcf41e4b2e93471f9e81102