### PR TITLE
Annotate return type of `useSourceActor` explicitly in an attempt to fix false positive diagnostics in CRA

### DIFF
--- a/src/sourceMachine.ts
+++ b/src/sourceMachine.ts
@@ -565,7 +565,7 @@ export const getSourceActor = (state: StateFrom<typeof authMachine>) =>
 
 export const useSourceActor = (
   authService: ActorRefFrom<typeof authMachine>,
-) => {
+): [SourceMachineState, SourceMachineActorRef['send']] => {
   const sourceService = useSelector(authService, getSourceActor);
 
   return useActor(sourceService!);


### PR DESCRIPTION
Just an attempt at improving the situation with the false-positive type errors reported by CRA. Both @farskid and me have been experiencing this problem.

It seems that the situation got better for me with this. I can't be completely sure though because we are not 100% sure how to trigger that false positive.