### PR TITLE
Changed fork to use the new forkSourceFile method from the registry

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,6 @@
 {
   "baseUrl": "http://localhost:3000",
   "viewportWidth": 1280,
-  "viewportHeight": 800
+  "viewportHeight": 800,
+  "defaultCommandTimeout": 8000
 }

--- a/cypress/integration/autocomplete.spec.ts
+++ b/cypress/integration/autocomplete.spec.ts
@@ -4,7 +4,7 @@ describe('Autocomplete in the editor', () => {
     cy.getMonacoEditor().type('{enter}{enter}ass');
 
     // Wait for the autocomplete to show up
-    cy.contains('assign', { timeout: 8000 });
+    cy.contains('assign');
 
     cy.getMonacoEditor().type('{downarrow}{downarrow}{enter}');
 
@@ -16,7 +16,7 @@ describe('Autocomplete in the editor', () => {
     cy.getMonacoEditor().type('{enter}{enter}createMod');
 
     // Wait for the autocomplete to show up
-    cy.contains('createModel', { timeout: 8000 });
+    cy.contains('createModel');
 
     cy.getMonacoEditor().type('{downarrow}{enter}');
 

--- a/cypress/integration/forking.spec.ts
+++ b/cypress/integration/forking.spec.ts
@@ -13,7 +13,7 @@ describe('Forking', () => {
           },
           text: '// Source file',
         },
-        createSourceFile: {
+        forkSourceFile: {
           id: 'source-file-id-2',
           name: 'Source File',
           owner: {
@@ -54,7 +54,7 @@ describe('Forking', () => {
           },
           text: '// Source file',
         },
-        createSourceFile: {
+        forkSourceFile: {
           id: 'source-file-id-2',
           name: 'Source File',
           owner: {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -44,11 +44,7 @@ const interceptGraphQL = (data: DeepPartial<Mutation & Query>) => {
 };
 
 const getCanvas = () => {
-  return cy.get('[data-panel="viz"]', {
-    // This needs to be this long in order for the
-    // ts worker to load initially
-    timeout: 8000,
-  });
+  return cy.get('[data-panel="viz"]');
 };
 
 /**

--- a/src/graphql/ForkSourceFile.graphql
+++ b/src/graphql/ForkSourceFile.graphql
@@ -1,0 +1,5 @@
+mutation ForkSourceFile($forkFromId: String!, $text: String!, $name: String!) {
+  forkSourceFile(text: $text, name: $name, forkFromId: $forkFromId) {
+    ...SourceFile
+  }
+}

--- a/src/sourceMachine.ts
+++ b/src/sourceMachine.ts
@@ -35,6 +35,7 @@ import { localCache } from './localCache';
 import { notifMachine, notifModel } from './notificationMachine';
 import { gQuery, updateQueryParamsWithoutReload } from './utils';
 import { SourceProvider } from './types';
+import { ForkSourceFileDocument } from './graphql/ForkSourceFile.generated';
 
 export const sourceModel = createModel(
   {
@@ -471,11 +472,11 @@ export const makeSourceMachine = (auth: SupabaseAuthClient) => {
           },
         ),
         assignCreateSourceFileToContext: assign((context, _event: any) => {
-          const event: DoneInvokeEvent<CreateSourceFileMutation> = _event;
+          const event: DoneInvokeEvent<SourceFileFragment> = _event;
           return {
-            sourceID: event.data?.createSourceFile.id,
+            sourceID: event.data?.id,
             sourceProvider: 'registry',
-            sourceRegistryData: event.data.createSourceFile,
+            sourceRegistryData: event.data,
           };
         }),
         updateURLWithMachineID: (ctx) => {
@@ -520,7 +521,18 @@ export const makeSourceMachine = (auth: SupabaseAuthClient) => {
         },
       },
       services: {
-        createSourceFile: async (ctx, e) => {
+        createSourceFile: async (ctx, e): Promise<SourceFileFragment> => {
+          if (ctx.sourceID && ctx.sourceProvider === 'registry') {
+            return gQuery(
+              ForkSourceFileDocument,
+              {
+                text: ctx.sourceRawContent || '',
+                name: ctx.desiredMachineName || '',
+                forkFromId: ctx.sourceID,
+              },
+              auth.session()?.access_token!,
+            ).then((res) => res.data?.forkSourceFile!);
+          }
           return gQuery(
             CreateSourceFileDocument,
             {
@@ -529,7 +541,7 @@ export const makeSourceMachine = (auth: SupabaseAuthClient) => {
             },
             auth.session()?.access_token!,
           ).then((res) => {
-            return res.data;
+            return res.data?.createSourceFile!;
           });
         },
         updateSourceFile: async (ctx, e) => {


### PR DESCRIPTION
Also changes the default timeout of all commands in Cypress to `8000`, fixing some of the flakiness @Andarist was seeing

The idea of this PR in general is to capture the metadata from each fork, so we can later build a graph of the most popular ones.