### PR TITLE
Prevent the whole implementation of an anonymous inline action being displayed on a transition

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -106,11 +106,16 @@ export function getEdges(stateNode: StateNode): Array<Edge<any, any, any>> {
   return edges;
 }
 
+const isStringifiedFunction = (str: string): boolean =>
+  /^function\s*\(/.test(str) || str.includes('=>');
+
 export const getActionLabel = (action: ActionObject<any, any>) => {
+  if (typeof action.exec === 'function') {
+    return isStringifiedFunction(action.type) ? 'anonymous' : action.type;
+  }
   if (action.type !== 'xstate.assign') {
     return action.type;
   }
-
   switch (typeof action.assignment) {
     case 'object':
       const keys = Object.keys(action.assignment).join();


### PR DESCRIPTION
I feel like what got displayed here was not ideal. I could just limit this text **but** this still wouldn't be quite helpful for users as some random, and partial, code would get displayed on the viz. IMHO displaying `"anonymous"` is fine because it points the user in direction of naming that action.

I've chosen to check the `action.exec` property because only function actions are converted in a way that passes this check. This happens in XState [here](https://github.com/statelyai/xstate/blob/63c5313c8e0dc63c68a69c7237b5268e4dc04b1a/packages/core/src/actions.ts#L94-L99), [here](https://github.com/statelyai/xstate/blob/63c5313c8e0dc63c68a69c7237b5268e4dc04b1a/packages/core/src/actions.ts#L84-L88) and [here](https://github.com/statelyai/xstate/blob/63c5313c8e0dc63c68a69c7237b5268e4dc04b1a/packages/core/src/actions.ts#L102-L106). Only the first code that I've linked to results in a stringified function because it handles the case with inline actions in the config object.

The check for arrow function is simplistic but should work OK for the sane use cases.

<img width="804" alt="Screenshot 2021-08-04 at 15 31 29" src="https://user-images.githubusercontent.com/9800850/128196878-a1037951-19a5-470c-82b0-d41a8bec6efc.png">
