### PR TITLE
Add setup in Cypress for the inspector tests

### DIFF
--- a/cypress/integration/inspector.spec.ts
+++ b/cypress/integration/inspector.spec.ts
@@ -1,0 +1,19 @@
+import { createMachine } from 'xstate';
+
+describe('Inspector', () => {
+  it('should visualize an inspected machine', () => {
+    cy.visitInspector();
+
+    cy.inspectMachine(
+      createMachine({
+        id: 'my_inspected_machine',
+        initial: 'a',
+        states: {
+          a: {},
+        },
+      }),
+    );
+
+    cy.getCanvas().contains('my_inspected_machine');
+  });
+});

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -3,18 +3,15 @@
 import '@testing-library/cypress/add-commands';
 import 'cypress-localstorage-commands';
 import 'cypress-real-events/support';
+import { inspect, Inspector } from '@xstate/inspect';
+import {
+  createMachine,
+  interpret,
+  InterpreterFrom,
+  StateMachine,
+} from 'xstate';
+import { state } from './state';
 import { Mutation, Query } from '../../src/graphql/schemaTypes.generated';
-
-/**
- * Removes win.onbeforeunload
- *
- * If we don't do this, Cypress hangs
- */
-beforeEach(() => {
-  cy.window().then((win) => {
-    win.onbeforeunload = null;
-  });
-});
 
 const setMockAuthToken = () => {
   cy.setLocalStorage(
@@ -42,6 +39,98 @@ const interceptGraphQL = (data: DeepPartial<Mutation & Query>) => {
     },
   });
 };
+
+const installInspectorProxyListener = () => {
+  const inspectorProxyListener = (event: MessageEvent<any>) => {
+    if (
+      event.data &&
+      typeof event.data === 'object' &&
+      typeof event.data.type === 'string' &&
+      /^xstate\./.test(event.data.type)
+    ) {
+      window.dispatchEvent(new MessageEvent(event.type, { data: event.data }));
+    }
+  };
+  window.parent.addEventListener('message', inspectorProxyListener);
+
+  state('@@viz/removeInspectorProxyListener', () =>
+    window.parent.removeEventListener('message', inspectorProxyListener),
+  );
+};
+
+const visitInspector = () => {
+  if (state('@@viz/inspectorInitialized')) {
+    throw new Error('Inspector has already been visited in this test.');
+  }
+  state('@@viz/inspectorInitialized', true);
+
+  cy.log('Visit inspector');
+  cy.wrap(null, { log: false }).then(() => {
+    installInspectorProxyListener();
+
+    // `inspect` sets the `iframe.src` internally
+    const inspector = inspect({
+      iframe: () =>
+        window.parent.document.querySelector<HTMLIFrameElement>('.aut-iframe'),
+      url: Cypress.config('baseUrl')!,
+    })!;
+    state('@@viz/inspector', inspector);
+  });
+};
+
+const waitOnInspector = (inspector: Inspector) =>
+  new Promise<void>((resolve) => {
+    let resolved = false;
+    let unsubscribe: () => void;
+
+    unsubscribe = inspector.subscribe((state) => {
+      if (state.value === 'connected') {
+        resolved = true;
+        if (unsubscribe) {
+          unsubscribe();
+        }
+        resolve();
+      }
+    }).unsubscribe;
+
+    // it's a hack to trigger the underlying subscribe's callback
+    // that will call our local callback here synchronously with the current state
+    inspector.send({ type: 'unknown_ping' } as any);
+
+    if (resolved) {
+      unsubscribe();
+    }
+  });
+
+function inspectMachine<T extends StateMachine<any, any, any, any>>(
+  machine: T,
+) {
+  const inspector = state('@@viz/inspector');
+  if (!inspector) {
+    throw new Error(
+      '`cy.inspectMachine` can only be used after `cy.visitInspector`',
+    );
+  }
+
+  cy.log(`inspectMachine: ${machine.id}`);
+
+  return cy.window({ log: false }).then(() => {
+    return waitOnInspector(inspector).then(() => {
+      const service = interpret(machine, { devTools: true });
+
+      // temp fix for @xstate/inspect bug
+      // we are interpreting machines when the inspect machine is already in the `connected` state
+      // this makes this `service.event` sent to the inspector right within the `.start()` call:
+      // https://github.com/statelyai/xstate/blob/fb7ea97465dfba0b7ef17edbf327c7c21848c7e8/packages/xstate-inspect/src/browser.ts#L171-L175
+      // but the `service._state` has never been assigned yet up to this point so it's `undefined`
+      // that gets forwarded to the inspector and throws here on `JSON.parse(undefined)`:
+      // https://github.com/statelyai/xstate/blob/fb7ea97465dfba0b7ef17edbf327c7c21848c7e8/packages/xstate-inspect/src/utils.ts#L38
+      (service as any)._state = service.initialState;
+
+      return service.start() as InterpreterFrom<T>;
+    });
+  });
+}
 
 const getCanvas = () => {
   return cy.get('[data-panel="viz"]');
@@ -85,6 +174,10 @@ declare global {
       getCanvas: typeof getCanvas;
 
       getMonacoEditor: typeof getMonacoEditor;
+
+      visitInspector: typeof visitInspector;
+
+      inspectMachine: typeof inspectMachine;
     }
   }
 }
@@ -93,3 +186,5 @@ Cypress.Commands.add('setMockAuthToken', setMockAuthToken);
 Cypress.Commands.add('getMonacoEditor', getMonacoEditor);
 Cypress.Commands.add('getCanvas', getCanvas);
 Cypress.Commands.add('interceptGraphQL', interceptGraphQL);
+Cypress.Commands.add('visitInspector', visitInspector);
+Cypress.Commands.add('inspectMachine', inspectMachine);

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -5,16 +5,27 @@
 // This is a great place to put global configuration and
 // behavior that modifies Cypress.
 //
-// You can change the location of this file or turn off
-// automatically serving support files with the
-// 'supportFile' configuration option.
-//
-// You can read more here:
-// https://on.cypress.io/configuration
 // ***********************************************************
 
-// Import commands.js using ES2015 syntax:
+import { InspectorOptions } from '@xstate/inspect';
 import './commands';
+import { state } from './state';
 
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
+type AnyFunction = (...args: any[]) => any;
+
+declare global {
+  interface Window {
+    __xstate__: Exclude<InspectorOptions['devTools'], AnyFunction>;
+  }
+}
+
+afterEach(() => {
+  const inspector = state('@@viz/inspector');
+  if (!inspector) {
+    return;
+  }
+  inspector.disconnect();
+  // https://github.com/statelyai/xstate/blob/fb7ea97465dfba0b7ef17edbf327c7c21848c7e8/packages/xstate-inspect/src/browser.ts#L68
+  const devTools = window.__xstate__;
+  devTools.services.forEach(devTools.unregister);
+});

--- a/cypress/support/state.ts
+++ b/cypress/support/state.ts
@@ -1,0 +1,13 @@
+import { Inspector } from '@xstate/inspect';
+
+interface State {
+  (key: '@@viz/inspectorInitialized'): boolean | undefined;
+  (key: '@@viz/inspectorInitialized', initialized: true): void;
+  (key: '@@viz/removeInspectorProxyListener'): (() => void) | undefined;
+  (key: '@@viz/removeInspectorProxyListener', removeListener: () => void): void;
+  (key: '@@viz/inspector'): Inspector | undefined;
+  (key: '@@viz/inspector', inspector: Inspector): void;
+}
+
+// wrap `cy.state` since it's not documented and thus it's also not typed so we have to type it ourselves
+export const state: State = (...args: any[]) => (cy as any).state(...args);

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
   },
   "eslintConfig": {
     "extends": [
-      "react-app",
-      "react-app/jest"
+      "react-app"
     ]
   },
   "browserslist": {

--- a/src/simulationMachine.tsx
+++ b/src/simulationMachine.tsx
@@ -144,7 +144,13 @@ export const simulationMachine = simModel.createMachine({
     {
       id: 'receiver',
       src: () => (sendBack, onReceive) => {
-        const receiver = createWindowReceiver();
+        const receiver = createWindowReceiver({
+          // for some random reason the `window.top` is being rewritten to `window.self`
+          // looks like maybe some webpack replacement plugin (or similar) plays tricks on us
+          // this breaks the auto-detection of the correct `targetWindow` in the `createWindowReceiver`
+          // so we pass it explicitly here
+          targetWindow: window.parent,
+        });
         (window as any).receiver = receiver;
 
         onReceive((event) => {


### PR DESCRIPTION
This adds setup for writing tests targeting the inspector and adds a basic test using that setup:
<img width="1675" alt="Screenshot 2021-08-05 at 13 48 53" src="https://user-images.githubusercontent.com/9800850/128345151-9c5ec1b3-5f5f-44c8-88a2-ec54363bb17f.png">
