### PR TITLE
Patch Supabase to avoid unsafe `localStorage` access

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "graphql:codegen": "graphql-codegen --watch",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "postinstall": "mkdir -p public/monaco-editor && cp -r node_modules/monaco-editor public",
+    "postinstall": "patch-package && mkdir -p public/monaco-editor && cp -r node_modules/monaco-editor public",
     "cypress:open": "cypress open",
     "cypress:test": "cypress run"
   },
@@ -80,6 +80,7 @@
     "cypress-localstorage-commands": "^1.5.0",
     "cypress-real-events": "^1.5.0",
     "graphql": "^15.5.0",
+    "patch-package": "^6.4.7",
     "sass": "^1.33.0",
     "serve": "^12.0.0",
     "source-map-explorer": "^2.5.2",

--- a/patches/@supabase+gotrue-js+1.16.5.patch
+++ b/patches/@supabase+gotrue-js+1.16.5.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/@supabase/gotrue-js/dist/module/GoTrueClient.js b/node_modules/@supabase/gotrue-js/dist/module/GoTrueClient.js
+index d62fce1..ade16ea 100644
+--- a/node_modules/@supabase/gotrue-js/dist/module/GoTrueClient.js
++++ b/node_modules/@supabase/gotrue-js/dist/module/GoTrueClient.js
+@@ -16,7 +16,10 @@ const DEFAULT_OPTIONS = {
+     url: GOTRUE_URL,
+     autoRefreshToken: true,
+     persistSession: true,
+-    localStorage: globalThis.localStorage,
++    // accessing this in 3rd party iframe (like when inspector is embedded as iframe on a page) in the incognito mode might throw:
++    // Uncaught DOMException: Failed to read the 'localStorage' property from 'Window': Access is denied for this document.
++    //
++    // localStorage: globalThis.localStorage,
+     detectSessionInUrl: true,
+     headers: DEFAULT_HEADERS,
+ };

--- a/src/authMachine.ts
+++ b/src/authMachine.ts
@@ -27,6 +27,7 @@ import {
   SourceMachineActorRef,
   sourceModel,
 } from './sourceMachine';
+import { storage } from './localCache';
 import { gQuery } from './utils';
 
 const authModel = createModel(
@@ -102,6 +103,7 @@ export const authMachine = createMachine<typeof authModel>(
             const client = createClient(
               process.env.REACT_APP_SUPABASE_API_URL,
               process.env.REACT_APP_SUPABASE_ANON_API_KEY,
+              { localStorage: storage as Storage },
             );
 
             return {

--- a/src/localCache.ts
+++ b/src/localCache.ts
@@ -2,7 +2,9 @@ import { isAfter } from 'date-fns';
 import { createStorage, testStorageSupport } from 'memory-web-storage';
 import { ThemeName, themes } from './editor-themes';
 
-const storage = testStorageSupport() ? window.localStorage : createStorage();
+export const storage = testStorageSupport()
+  ? window.localStorage
+  : createStorage();
 
 export interface CachedPosition {
   zoom: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4012,6 +4012,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 "@zeit/schemas@2.6.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@zeit/schemas/-/schemas-2.6.0.tgz#004e8e553b4cd53d538bd38eac7bcbf58a867fe3"
@@ -6011,7 +6016,7 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^6.0.0:
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -7737,6 +7742,13 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -7878,7 +7890,7 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
-fs-extra@^7.0.0:
+fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -10016,6 +10028,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -11186,7 +11205,7 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
-open@^7.0.2, open@^7.3.1:
+open@^7.0.2, open@^7.3.1, open@^7.4.2:
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
   integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
@@ -11459,6 +11478,25 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+patch-package@^6.4.7:
+  version "6.4.7"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.4.7.tgz#2282d53c397909a0d9ef92dae3fdeb558382b148"
+  integrity sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
 
 path-browserify@0.0.1:
   version "0.0.1"
@@ -13820,6 +13858,11 @@ sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slash@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
When testing the inspector in CodeSandbox in the incognito mode I've noticed that Supabase throws on this:
<img width="541" alt="Screenshot 2021-08-05 at 14 40 22" src="https://user-images.githubusercontent.com/9800850/128353317-6acce108-84e1-4f0c-afec-44270f1220a3.png">

So I've patched this on our side and I intend to raise an issue in the appropriate Supabase repo