### PR TITLE
Make all appropriate tab panels scrollable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -113,7 +113,7 @@ function App() {
                     </TabList>
 
                     <TabPanels minHeight={0}>
-                      <TabPanel padding={0} height="100%">
+                      <TabPanel height="100%" padding={0}>
                         {sourceState.matches({
                           with_source: 'loading_content',
                         }) && (
@@ -156,16 +156,16 @@ function App() {
                           />
                         )}
                       </TabPanel>
-                      <TabPanel height="100%">
+                      <TabPanel height="100%" overflowY="auto">
                         <StatePanel />
                       </TabPanel>
-                      <TabPanel overflow="hidden" height="100%">
+                      <TabPanel height="100%" overflow="hidden">
                         <EventsPanel />
                       </TabPanel>
-                      <TabPanel height="100%">
+                      <TabPanel height="100%" overflowY="auto">
                         <ActorsPanel />
                       </TabPanel>
-                      <TabPanel height="100%">
+                      <TabPanel height="100%" overflowY="auto">
                         <SettingsPanel />
                       </TabPanel>
                     </TabPanels>


### PR DESCRIPTION
I've noticed that State, Actors & Settings panels were not scrollable - so here is a fix for that