### PR TITLE
Avoid duplicated CSS rules by preventing SCSS files being imported/used more than once

### DIFF
--- a/src/TransitionViz.scss
+++ b/src/TransitionViz.scss
@@ -1,5 +1,3 @@
-@import './base.scss';
-
 [data-viz='transitions'] {
   display: flex;
   flex-direction: column;

--- a/src/useInterpretCanvas.ts
+++ b/src/useInterpretCanvas.ts
@@ -1,6 +1,5 @@
 import { useInterpret } from '@xstate/react';
 import { useEffect } from 'react';
-import './base.scss';
 import { canvasMachine } from './canvasMachine';
 import './Graph';
 import { localCache } from './localCache';


### PR DESCRIPTION
I've noticed that this file was loaded more than once while it could only be imported in the `App.tsx` here:
https://github.com/statelyai/xstate-viz/blob/7e59c177792af45516eeda5934a2ed7ca7c3d1b2/src/App.tsx#L17

<img width="500" alt="Screenshot 2021-08-06 at 14 22 18" src="https://user-images.githubusercontent.com/9800850/128509710-81e4b404-f3aa-4cde-88e4-a70fbaaf8ac3.png">
