### PR TITLE
Workaround a flaky test by awaiting the machine to get vizualized

### DIFF
--- a/cypress/integration/gist.spec.ts
+++ b/cypress/integration/gist.spec.ts
@@ -45,7 +45,7 @@ describe('Gists', () => {
       },
     });
 
-    cy.getCanvas();
+    cy.getCanvas().contains('gistMachine');
 
     cy.findByRole('button', { name: /Fork/i }).click();
 


### PR DESCRIPTION
I've cherry-picked this from my other PR: https://github.com/statelyai/xstate-viz/pull/156 because it seems to affect most of the recent builds so it would be great to get this into `main` asap.

Explanation behind this can be found here: https://github.com/statelyai/xstate-viz/pull/156#discussion_r684188749