### PR TITLE
Fix `zIndex` issue with events table and logged in user Menu

### DIFF
--- a/src/EventsPanel.tsx
+++ b/src/EventsPanel.tsx
@@ -220,7 +220,7 @@ export const EventsPanel: React.FC = () => {
         </Box>
       </Box>
       <Box overflowY="auto">
-        <Table width="100%" isolation="isolate">
+        <Table width="100%">
           <Thead>
             <Tr>
               <Th {...stickyProps} width="100%">

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -14,6 +14,7 @@ import {
   ModalHeader,
   ModalOverlay,
   Text,
+  Portal,
 } from '@chakra-ui/react';
 import { useActor } from '@xstate/react';
 import React from 'react';
@@ -55,25 +56,27 @@ export const Login: React.FC = () => {
               width="30px"
             />
           </MenuButton>
-          <MenuList>
-            {state.context.loggedInUserData && (
+          <Portal>
+            <MenuList>
+              {state.context.loggedInUserData && (
+                <MenuItem
+                  as="a"
+                  href={registryLinks.viewUserById(
+                    state.context.loggedInUserData.id,
+                  )}
+                >
+                  View Machines
+                </MenuItem>
+              )}
               <MenuItem
-                as="a"
-                href={registryLinks.viewUserById(
-                  state.context.loggedInUserData.id,
-                )}
+                onClick={() => {
+                  authService.send('SIGN_OUT');
+                }}
               >
-                View Machines
+                Logout
               </MenuItem>
-            )}
-            <MenuItem
-              onClick={() => {
-                authService.send('SIGN_OUT');
-              }}
-            >
-              Logout
-            </MenuItem>
-          </MenuList>
+            </MenuList>
+          </Portal>
         </Menu>
       )}
 


### PR DESCRIPTION
Fixing:
<img src="https://uploads.linear.app/e8658b56-3771-46a0-85d9-7840fef33f0c/8672d620-6661-4e2c-83fc-2e18dc15c55e/dbf20d6d-bcbe-4300-917d-c8a6699415bb"/>

The direct reason why this was happening is this `zIndex` here:
https://github.com/statelyai/xstate-viz/blob/1916498a1554a726406d0656811390cc92ae108b/src/EventsPanel.tsx#L69
conflicting with the one set on the Menu.

I was wondering though - why did `zIndex` was needed? It turns out that without it the table rows were starting to cover the sticky header when scrolling down. A sticky element like this should normally not behave like though. This led me to creating an isolated repro of the problem:
https://jsfiddle.net/eqnox2tj/

As we may notice - only the first row acts as described, the rest is OK. It turns out that `position: relative;` is causing this! I don't exactly know why (if anyone knows - let me know).
