### PR TITLE
Fixed an issue with builds being skipped when multiple refs point to a single commit

### DIFF
--- a/vercel-ignore.sh
+++ b/vercel-ignore.sh
@@ -3,13 +3,22 @@
 # This script tells vercel which branches to build,
 # and which to ignore
 
+function get_branch_hash () {
+  local result="$(git rev-parse --short $1)"
+  echo "$result"
+}
+
 echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
 echo "VERCEL_GIT_COMMIT_SHA: $VERCEL_GIT_COMMIT_SHA"
+echo "main hash: $(get_branch_hash main)"
 
 if [[ "$VERCEL_GIT_COMMIT_REF" == "dev" || "$VERCEL_GIT_COMMIT_REF" == "staging" || "$VERCEL_GIT_COMMIT_REF" == "main" ]] ; then
   echo "✅ - Build can proceed"
   exit 1;
-elif [[ "$VERCEL_GIT_COMMIT_SHA" == "$(git rev-parse --short main)" ]] ; then
+# check if the current hash matches the tip of the main branch
+# multiple branches can point to a single hash
+# this tries to avoid a situation when a build targeting main gets skipped because a feature branch got assigned to VERCEL_GIT_COMMIT_REF
+elif [[ "$VERCEL_GIT_COMMIT_SHA" == "$(get_branch_hash main)" ]] ; then
   echo "✅ - Build can proceed"
   exit 1;
 else

--- a/vercel-ignore.sh
+++ b/vercel-ignore.sh
@@ -6,7 +6,7 @@
 function get_remote_branch_hash () {
   # get hash of a remote branch, grab the first word (the hash)
   # and format it with rev-parse to get a short hash that is comparable with VERCEL_GIT_COMMIT_SHA
-  local result="$(git rev-parse --short `git ls-remote origin main | awk '{ print $1 }'`)"
+  local result="$(git rev-parse --short `git ls-remote https://github.com/statelyai/xstate-viz.git main | awk '{ print $1 }'`)"
   echo "$result"
 }
 

--- a/vercel-ignore.sh
+++ b/vercel-ignore.sh
@@ -4,14 +4,15 @@
 # and which to ignore
 
 echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
+echo "VERCEL_GIT_COMMIT_SHA: $VERCEL_GIT_COMMIT_SHA"
 
-if [[ "$VERCEL_GIT_COMMIT_REF" == "dev" || "$VERCEL_GIT_COMMIT_REF" == "staging" || "$VERCEL_GIT_COMMIT_REF" == "main"  ]] ; then
-  # Proceed with the build
-    echo "✅ - Build can proceed"
+if [[ "$VERCEL_GIT_COMMIT_REF" == "dev" || "$VERCEL_GIT_COMMIT_REF" == "staging" || "$VERCEL_GIT_COMMIT_REF" == "main" ]] ; then
+  echo "✅ - Build can proceed"
   exit 1;
-
+elif [[ "$VERCEL_GIT_COMMIT_SHA" == "$(git rev-parse --short main)" ]] ; then
+  echo "✅ - Build can proceed"
+  exit 1;
 else
-  # Don't build
   echo "🛑 - Build cancelled"
   exit 0;
 fi

--- a/vercel-ignore.sh
+++ b/vercel-ignore.sh
@@ -3,14 +3,16 @@
 # This script tells vercel which branches to build,
 # and which to ignore
 
-function get_branch_hash () {
-  local result="$(git rev-parse --short $1)"
+function get_remote_branch_hash () {
+  # get hash of a remote branch, grab the first word (the hash)
+  # and format it with rev-parse to get a short hash that is comparable with VERCEL_GIT_COMMIT_SHA
+  local result="$(git rev-parse --short `git ls-remote origin main | awk '{ print $1 }'`)"
   echo "$result"
 }
 
 echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
 echo "VERCEL_GIT_COMMIT_SHA: $VERCEL_GIT_COMMIT_SHA"
-echo "main hash: $(get_branch_hash main)"
+echo "main hash: $(get_remote_branch_hash main)"
 
 if [[ "$VERCEL_GIT_COMMIT_REF" == "dev" || "$VERCEL_GIT_COMMIT_REF" == "staging" || "$VERCEL_GIT_COMMIT_REF" == "main" ]] ; then
   echo "✅ - Build can proceed"
@@ -18,7 +20,7 @@ if [[ "$VERCEL_GIT_COMMIT_REF" == "dev" || "$VERCEL_GIT_COMMIT_REF" == "staging"
 # check if the current hash matches the tip of the main branch
 # multiple branches can point to a single hash
 # this tries to avoid a situation when a build targeting main gets skipped because a feature branch got assigned to VERCEL_GIT_COMMIT_REF
-elif [[ "$VERCEL_GIT_COMMIT_SHA" == "$(get_branch_hash main)" ]] ; then
+elif [[ "$VERCEL_GIT_COMMIT_SHA" == "$(get_remote_branch_hash main)" ]] ; then
   echo "✅ - Build can proceed"
   exit 1;
 else


### PR DESCRIPTION
I **think** this should help with some builds being skipped (like this one https://vercel.com/statelyai/xstate-viz/J4ZsYesv6uiXyRpwz2wLwzEGQYBV ) when multiple refs point to a single branch.

Such a situation has resulted in:
> Cloning github.com/statelyai/xstate-viz (Branch: andarist/sta-320-events-panel-hiding-view-user-toolbar, Commit: 8e0810c)

Even though our intention was to check against the `main` branch. The problem is that Vercel deploys are per commit, and not per ref - since this is 1-to-many relationship, but only a single value can be assigned to a ref-related variable, this results in problems like this.

I was not yet available to confirm that this actually works - I can't easily (or I don't know how) test this with Vercel. I have no idea what info is actually available there, if they are doing full git clones, shallow ones or what. It's worth testing out though - the worst-case scenario is that this won't help.