### PR TITLE
Move global styles to Chakra theme

### DIFF
--- a/src/base.scss
+++ b/src/base.scss
@@ -1,14 +1,3 @@
-*,
-*:before,
-*:after {
-  box-sizing: border-box;
-  position: relative;
-}
-
-.monaco-editor * {
-  position: static;
-}
-
 [data-viz-theme] {
   background: var(--viz-color-bg);
   color: var(--viz-color-fg);
@@ -38,18 +27,4 @@
   --viz-node-parallel-border-style: dashed;
   --viz-font-size-base: 14px;
   --viz-font-size-sm: 12px;
-
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
-    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-}
-
-#root {
-  height: 100vh;
-  width: 100vw;
-  overflow: hidden;
-}
-
-body {
-  overscroll-behavior: none;
-  overflow: hidden;
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -9,6 +9,26 @@ const config: ThemeConfig = {
 // 3. extend the theme
 export const theme = extendTheme({
   config,
+  styles: {
+    global: {
+      '*, *:before, *:after': {
+        position: 'relative',
+      },
+      body: {
+        overflow: 'hidden',
+        overscrollBehavior: 'none',
+        fontFamily: `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif`,
+      },
+      '#root': {
+        height: '100vh',
+        width: '100vw',
+        overflow: 'hidden',
+      },
+      '.monaco-editor *': {
+        position: 'static',
+      },
+    },
+  },
   components: {
     Button: {
       variants: {


### PR DESCRIPTION
Just a small change to move global styles to Chakra theme - I've done this because I've noticed a global `box-sizing: border-box;` being duplicated (one coming from SCSS and one coming from Chakra's reset). This should help a little bit with keeping everything in a single place