### PR TITLE
Prioritize direction for initial edges

### DIFF
--- a/src/Graph.tsx
+++ b/src/Graph.tsx
@@ -136,6 +136,8 @@ function getElkEdge(
     edge,
     sections: [],
     layoutOptions: {
+      // Ensure that all edges originating from initial states point RIGHT
+      // (give them direction priority) so that the initial states can end up on the top left
       'elk.layered.priority.direction': isInitialEdge ? '1' : '0',
     },
   };

--- a/src/Graph.tsx
+++ b/src/Graph.tsx
@@ -110,6 +110,7 @@ function getElkEdge(
   const edgeRect = rectMap.get(edge.id)!;
   const targetPortId = getPortId(edge);
   const isSelfEdge = edge.source === edge.target;
+  const isInitialEdge = edge.source.parent?.initial === edge.source.key;
 
   const sources = [edge.source.id];
   const targets = isSelfEdge ? [getSelfPortId(edge.target.id)] : [targetPortId];
@@ -134,7 +135,9 @@ function getElkEdge(
     ],
     edge,
     sections: [],
-    layoutOptions: {},
+    layoutOptions: {
+      'elk.layered.priority.direction': isInitialEdge ? '1' : '0',
+    },
   };
 }
 


### PR DESCRIPTION
**Before:** Initial state placed at end because ELK is trying to prioritize the edge direction (`RIGHT`) equally for all edges, even the one that cycles back to the initial state, and it is prioritizing the incoming edges instead of the outgoing edges.

![CleanShot 2021-08-17 at 17 57 22](https://user-images.githubusercontent.com/1093738/129806333-27c57118-f2dc-4012-9130-6730db669d03.png)

**After:** By prioritizing edges whose source is an initial state, they are much more likely to point in the correct direction (`RIGHT`) instead of incoming edges:

![CleanShot 2021-08-17 at 17 58 32](https://user-images.githubusercontent.com/1093738/129806669-b75b889f-0790-47d0-bf78-6b6772242d60.png)

Test machine: https://stately.ai/viz?id=746de212-ed0a-44b5-81f7-d4f883bf2f92