### PR TITLE
Refactor spacing around bottom buttons in order to avoid using a fixed height on the button container

### DIFF
--- a/src/CanvasView.tsx
+++ b/src/CanvasView.tsx
@@ -90,10 +90,9 @@ export const CanvasView: React.FC = () => {
         position="absolute"
         bottom={0}
         left={0}
-        padding="2"
+        padding="3"
         zIndex={1}
         width="100%"
-        height="4rem"
       >
         <ButtonGroup size="sm" spacing={2} isAttached>
           <IconButton
@@ -123,7 +122,7 @@ export const CanvasView: React.FC = () => {
         {simulationMode === 'visualizing' && (
           <Button
             size="sm"
-            margin={2}
+            marginLeft={2}
             onClick={() => simService.send('MACHINES.RESET')}
             variant="secondary"
           >

--- a/src/EditorPanel.tsx
+++ b/src/EditorPanel.tsx
@@ -426,7 +426,7 @@ export const EditorPanel: React.FC<{
           }}
         />
       )}
-      <Box height="100%" display="grid" gridTemplateRows="1fr 4rem">
+      <Box height="100%" display="grid" gridTemplateRows="1fr auto">
         {simulationMode === 'visualizing' && (
           <>
             {/* This extra div acts as a placeholder that is supposed to stretch while EditorWithXStateImports lazy-loads (thanks to `1fr` on the grid) */}


### PR DESCRIPTION
Was trying to achieve the same visual effect without the fixed heights, as a CSS exercise for myself. Got the desired effect - so I thought it might be worth creating a PR with this. It feels like this is a spacing problem and as such a spacing-oriented solution seems to be more in the spirit of design systems 🤔 