### PR TITLE
Fixed an issue with global keybindings being also triggered when providing input to input-like elements

### DIFF
--- a/.changeset/strange-ligers-walk.md
+++ b/.changeset/strange-ligers-walk.md
@@ -1,0 +1,5 @@
+---
+'xstate-viz-app': patch
+---
+
+Fixed an issue with global keybindings being also triggered when providing input to input-like elements.

--- a/src/CanvasContainer.tsx
+++ b/src/CanvasContainer.tsx
@@ -4,7 +4,7 @@ import { useCanvas } from './CanvasContext';
 import { useMachine } from '@xstate/react';
 import { createModel } from 'xstate/lib/model';
 import { Point } from './pathUtils';
-import { isWithPlatformMetaKey } from './utils';
+import { isWithPlatformMetaKey, isInputLikeElement } from './utils';
 import { AnyState } from './types';
 
 const dragModel = createModel(
@@ -113,17 +113,14 @@ export const CanvasContainer: React.FC = ({ children }) => {
       services: {
         invokeDetectLock: () => (sendBack) => {
           function keydownListener(e: KeyboardEvent) {
+            const target = e.target as HTMLElement;
             // Need this to still be able to use Spacebar in editable elements
-            if (
-              ['TEXTAREA', 'INPUT', 'BUTTON'].includes(
-                document.activeElement?.nodeName!,
-              ) ||
-              document.activeElement?.hasAttribute('contenteditable')
-            ) {
+            if (isInputLikeElement(target) || target.tagName === 'BUTTON') {
               return;
             }
 
             if (e.code === 'Space') {
+              e.preventDefault();
               sendBack('LOCK');
             }
           }
@@ -136,6 +133,7 @@ export const CanvasContainer: React.FC = ({ children }) => {
         invokeDetectRelease: () => (sendBack) => {
           function keyupListener(e: KeyboardEvent) {
             if (e.code === 'Space') {
+              e.preventDefault();
               sendBack('RELEASE');
             }
           }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,0 @@
-export const EDITOR_CLASSNAME = '.js-monaco-editor';

--- a/src/paletteMachine.ts
+++ b/src/paletteMachine.ts
@@ -1,6 +1,5 @@
 import { createModel } from 'xstate/lib/model';
-import { EDITOR_CLASSNAME } from './constants';
-import { isWithPlatformMetaKey } from './utils';
+import { isWithPlatformMetaKey, isInputLikeElement } from './utils';
 
 const paletteModel = createModel(undefined, {
   events: {
@@ -23,14 +22,10 @@ export const paletteMachine = paletteModel.createMachine({
             };
             return Object.values(keybindings).some(Boolean);
           }
-          function eventRoseFromEditor(e: KeyboardEvent) {
-            const editorElement = document.querySelector(EDITOR_CLASSNAME);
-            return editorElement && editorElement.contains(e.target as Node);
-          }
           const eventHandler = (e: KeyboardEvent) => {
             if (
-              captureCommandPaletteKeybindings(e) &&
-              !eventRoseFromEditor(e)
+              !isInputLikeElement(e.target as HTMLElement) &&
+              captureCommandPaletteKeybindings(e)
             ) {
               e.preventDefault();
               sendBack('SHOW_PALETTE');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -202,3 +202,6 @@ export function isDelayedTransitionAction(
       return false;
   }
 }
+
+export const isInputLikeElement = (el: HTMLElement) =>
+  el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable;


### PR DESCRIPTION
This moves a fix from here: https://github.com/statelyai/xstate-viz/pull/203#discussion_r693093759 and also makes it better because this was only handling the Monaco editors. This PR fixes the problem for all kind of input-like elements. In our application this includes:
- event payload's JSON Monaco
- event list filter input
- name chooser input in a modal