### PR TITLE
Recoloured viz based on user feedback

### DIFF
--- a/.changeset/rude-brooms-rule.md
+++ b/.changeset/rude-brooms-rule.md
@@ -1,0 +1,5 @@
+---
+"xstate-viz-app": patch
+---
+
+Recoloured viz based on user feedback. This change deprioritises actions you can't trigger, adds a faded out blue border to states to indicate they're different from events, and deepens the primary blue to increase accessibility.

--- a/src/ActionViz.scss
+++ b/src/ActionViz.scss
@@ -1,5 +1,4 @@
 [data-viz='action'] {
-  color: var(--viz-color-fg);
   display: flex;
   flex-direction: row;
   gap: 1ch;

--- a/src/StateNodeViz.scss
+++ b/src/StateNodeViz.scss
@@ -64,7 +64,7 @@
 
 [data-viz='stateNode-content'] {
   background: var(--viz-node-color-bg);
-  padding: 0.6rem 1.4rem;
+  padding: 0.5rem 1.5rem;
 
   &:empty {
     display: none;

--- a/src/StateNodeViz.scss
+++ b/src/StateNodeViz.scss
@@ -64,7 +64,7 @@
 
 [data-viz='stateNode-content'] {
   background: var(--viz-node-color-bg);
-  padding: 1rem 2rem;
+  padding: 0.6rem 1.4rem;
 
   &:empty {
     display: none;

--- a/src/StateNodeViz.scss
+++ b/src/StateNodeViz.scss
@@ -1,5 +1,5 @@
 [data-viz='stateNodeGroup'] {
-  --viz-node-border-color: var(--viz-border-color);
+  --viz-node-border-color: var(--viz-color-active-muted);
   --viz-node-active: 0;
   --viz-transition-color: #555;
 

--- a/src/StateNodeViz.scss
+++ b/src/StateNodeViz.scss
@@ -64,6 +64,7 @@
 
 [data-viz='stateNode-content'] {
   background: var(--viz-node-color-bg);
+  padding: 1rem 2rem;
 
   &:empty {
     display: none;

--- a/src/TransitionViz.scss
+++ b/src/TransitionViz.scss
@@ -1,15 +1,17 @@
 [data-viz='transition'] {
-  --viz-transition-color: #333;
+  --viz-transition-color: black;
   display: block;
   border-radius: 0.4rem;
   background-color: var(--viz-transition-color);
   appearance: none;
+  border: #555 2px solid;
 
   color: #ccc;
 
   &[data-viz-potential] {
     --viz-transition-color: var(--viz-color-active);
     color: white;
+    border-color: var(--viz-color-active);
   }
 
   > [data-viz='transition-label'] {

--- a/src/TransitionViz.scss
+++ b/src/TransitionViz.scss
@@ -1,12 +1,15 @@
 [data-viz='transition'] {
-  --viz-transition-color: gray;
+  --viz-transition-color: #333;
   display: block;
-  border-radius: 1rem;
+  border-radius: 0.4rem;
   background-color: var(--viz-transition-color);
   appearance: none;
 
+  color: #ccc;
+
   &[data-viz-potential] {
     --viz-transition-color: var(--viz-color-active);
+    color: white;
   }
 
   > [data-viz='transition-label'] {
@@ -25,7 +28,6 @@
   flex-shrink: 0;
   font-size: var(--viz-font-size-sm);
   font-weight: bold;
-  color: white;
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/src/base.scss
+++ b/src/base.scss
@@ -18,8 +18,9 @@
 
   --viz-color-transparent: #fff6;
   --viz-color-active: turquoise;
-  --viz-color-active: #679ae7;
-  --viz-border-color: var(--viz-node-color-bg);
+  --viz-color-active: #4378b5;
+  --viz-color-active-muted: #5d79b6;
+  --viz-border-color: #999;
   --viz-border-width: 2px;
   --viz-border: var(--viz-border-width) solid var(--viz-border-color);
   --viz-radius: 0.25rem;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28293365/130592301-f4b020ce-c850-43a9-9ee4-45a6847fb6b9.png)

This deprioritises actions you can't trigger, adds a faded out blue border to states to indicate what they are, and deepens the primary blue to increase accessibility.