### PR TITLE
Fixed an invalid DOM nesting in the hamburger menu

### DIFF
--- a/src/CanvasHeader.tsx
+++ b/src/CanvasHeader.tsx
@@ -60,13 +60,12 @@ export const CanvasHeader: React.FC = () => {
             <LikeButton />
             <ShareButton />
             <Menu closeOnSelect>
-              <MenuButton>
-                <IconButton
-                  aria-label="Menu"
-                  icon={<HamburgerIcon />}
-                  size="sm"
-                ></IconButton>
-              </MenuButton>
+              <MenuButton
+                as={IconButton}
+                aria-label="Menu"
+                icon={<HamburgerIcon />}
+                size="sm"
+              />
               <MenuList>
                 {userOwnsSource && sourceState.context.sourceID && (
                   <MenuItem


### PR DESCRIPTION
I've noticed an error in the console warning about this:
> Warning: validateDOMNesting(...): <button> cannot appear as a descendant of <button>.

So I've located it to be about this hamburger menu:
<img width="1070" alt="Screenshot 2021-08-27 at 11 26 44" src="https://user-images.githubusercontent.com/9800850/131105943-5e2a3e32-4509-48d9-a48f-42d57928d484.png">
