### PR TITLE
Fix getLCA

### DIFF
--- a/.changeset/tall-boats-melt.md
+++ b/.changeset/tall-boats-melt.md
@@ -3,3 +3,5 @@
 ---
 
 The layout algorithm was parenting some of the edges incorrectly. This has been fixed.
+
+![CleanShot 2021-08-30 at 07 14 58](https://user-images.githubusercontent.com/1093738/131331546-4a780c96-c58e-498e-aeaa-f44dc5e81fb4.png)

--- a/.changeset/tall-boats-melt.md
+++ b/.changeset/tall-boats-melt.md
@@ -1,0 +1,5 @@
+---
+'xstate-viz-app': patch
+---
+
+The layout algorithm was parenting some of the edges incorrectly. This has been fixed.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,3 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/graphUtils.ts
+++ b/src/graphUtils.ts
@@ -59,30 +59,33 @@ function getRelativeNodeEdgeMap(
   const map: RelativeNodeEdgeMap[0] = new Map();
   const edgeMap: RelativeNodeEdgeMap[1] = new Map();
 
-  const getLCA = (a: StateNode, b: StateNode): StateNode | undefined => {
-    if (a === b) {
-      return a.parent;
+  const getLCA = (
+    sourceNode: StateNode,
+    targetNode: StateNode,
+  ): StateNode | undefined => {
+    if (sourceNode === targetNode) {
+      return sourceNode.parent;
     }
 
-    const set = new Set();
+    const set = new Set([sourceNode]);
 
-    let m = a.parent;
+    let marker = sourceNode.parent;
 
-    while (m) {
-      set.add(m);
-      m = m.parent;
+    while (marker) {
+      set.add(marker);
+      marker = marker.parent;
     }
 
-    m = b;
+    marker = targetNode;
 
-    while (m) {
-      if (set.has(m)) {
-        return m;
+    while (marker) {
+      if (set.has(marker)) {
+        return marker;
       }
-      m = m.parent;
+      marker = marker.parent;
     }
 
-    return a.machine; // root
+    return sourceNode.machine; // root
   };
 
   edges.forEach((edge) => {

--- a/src/graphUtils.ts
+++ b/src/graphUtils.ts
@@ -55,6 +55,8 @@ export function getAllEdges(digraph: DirectedGraphNode): DirectedGraphEdge[] {
  * Returns the node that contains the `source` and `target` of the edges, which may be
  * the `source` or `target` itself.
  *
+ * See https://www.eclipse.org/elk/documentation/tooldevelopers/graphdatastructure/coordinatesystem.html
+ *
  * @param edge
  * @returns containing node
  */


### PR DESCRIPTION
This PR fixes the `getLCA(...)` function. The problem was that it was previously not considering the source node to potentially be a LCA.

Fixes #227 

**Before:**
![Before](https://user-images.githubusercontent.com/1588547/131266955-2de2c698-36cc-474b-93bb-103c038087c1.png)

**After:**
![CleanShot 2021-08-29 at 21 53 00](https://user-images.githubusercontent.com/1093738/131274676-fa4ecd01-ef2e-4097-8acd-fd7ca0ede60d.png)
