### PR TITLE
Drop broken/incomplete logic for prompting for event schema values

### DIFF
--- a/src/simulationMachine.tsx
+++ b/src/simulationMachine.tsx
@@ -283,22 +283,6 @@ export const simulationMachine = simModel.createMachine(
       },
       'SERVICE.SEND': {
         actions: [
-          (ctx, e) => {
-            const eventSchema =
-              ctx.serviceDataMap[ctx.currentSessionId!]!.machine.schema
-                ?.events?.[e.event.type];
-            const eventToSend = { ...e.event };
-
-            if (eventSchema) {
-              Object.keys(eventSchema.properties).forEach((prop) => {
-                const value = prompt(
-                  `Enter value for "${prop}" (${eventSchema.properties[prop].type}):`,
-                );
-
-                eventToSend.data[prop] = value;
-              });
-            }
-          },
           send(
             (ctx, e) => {
               return {


### PR DESCRIPTION
When reviewing https://github.com/statelyai/xstate-viz/pull/256 I've noticed that this piece of code has some serious issues so I think that it's best to drop this entirely for the time being.

1. it's prompting for all properties - even if they are already defined. It's clashing with the events coming from the `<NewEvent/>` as those could already define the required props. Could this be fixed by conditionally prompting against missing values? Yeah, sure... but...
2. this doesn't actually use the schema at all - it just prompts for the given keys. This would fail for any non-string values. Given that fact, I believe that it's better to remove this code for now and revisit it with a more complete solution in the future.
3. this logic first **clones** the received event and then **mutates** the deep property (which has not been cloned with spread). So this might work... but it probably could be done in a more explicit way that would be easier to follow.