### PR TITLE
Disable cache and confirmation in embedded mode

### DIFF
--- a/src/pages/embed/[sourceFileId].tsx
+++ b/src/pages/embed/[sourceFileId].tsx
@@ -41,7 +41,7 @@ export const getServerSideProps: GetServerSideProps<
 > = async (ctx) => {
   if (ctx.query.ssr) {
     return {
-      props: JSON.parse(ctx.query.ssr as string),
+      props: { ...JSON.parse(ctx.query.ssr as string), isEmbedded: true },
     };
   }
 
@@ -61,6 +61,7 @@ export const getServerSideProps: GetServerSideProps<
     props: {
       id: sourceFileId,
       data: result.data?.getSourceFile,
+      isEmbedded: true,
     },
   };
 };

--- a/src/sourceMachine.ts
+++ b/src/sourceMachine.ts
@@ -155,7 +155,9 @@ function getInvocations(isEmbedded: boolean) {
         id: 'confirmBeforeLeavingMachine',
       },
     ];
-  } else [];
+  }
+
+  return [];
 }
 
 export const makeSourceMachine = (params: {


### PR DESCRIPTION
Correctly detect embedded mode in auth and source machine to disable cache and confirmation services