### PR TITLE
Include sourcemaps in production

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,6 +16,7 @@ module.exports = {
     ignoreBuildErrors: true,
   },
   basePath: `/viz`,
+  productionBrowserSourceMaps: true,
   /**
    * These rewrites are never used in production - only in development
    */


### PR DESCRIPTION
Source Maps will make it easier to inspect the visualizer with browser devtools and Replay.io