### PR TITLE
Fixed visual alignment of canvas and editor buttons

### DIFF
--- a/src/CanvasView.tsx
+++ b/src/CanvasView.tsx
@@ -73,7 +73,7 @@ export const CanvasView: React.FC = () => {
     <Box
       display="grid"
       height="100%"
-      {...(!embed?.isEmbedded && { gridTemplateRows: '3rem 1fr' })}
+      {...(!embed?.isEmbedded && { gridTemplateRows: '3rem 1fr auto' })}
     >
       {!embed?.isEmbedded && (
         <Box data-testid="canvas-header" bg="gray.800" zIndex={1} padding="0">
@@ -103,10 +103,10 @@ export const CanvasView: React.FC = () => {
           position="absolute"
           bottom={0}
           left={0}
-          padding="2"
+          paddingX={2}
+          paddingY={3}
           zIndex={1}
           width="100%"
-          height="4rem"
           data-testid="controls"
         >
           <ButtonGroup size="sm" spacing={2} isAttached>


### PR DESCRIPTION
Fixes a visual regression (caught by a cypress test!) from https://github.com/statelyai/xstate-viz/pull/217 

**Before**

<img width="420" alt="Screenshot 2021-09-22 at 14 31 15" src="https://user-images.githubusercontent.com/9800850/134343994-3a7dd026-2fce-412e-9a47-b478b2166442.png">

**After**
<img width="405" alt="Screenshot 2021-09-22 at 14 30 41" src="https://user-images.githubusercontent.com/9800850/134343977-9ef73cde-a94a-4968-993e-12cb41000711.png">
