### PR TITLE
Fixed extracting the latest release changelog content in the `publish-github-release` script

### DIFF
--- a/scripts/publish-github-release.js
+++ b/scripts/publish-github-release.js
@@ -16,7 +16,7 @@ async function publishRelease(octokit, { repo }) {
     'utf-8',
   );
 
-  const versionHeader = /^##/gm;
+  const versionHeader = /^##(?!#)/gm;
 
   // we leverage statefulness of `g` regex here for the second `exec` to start of the `lastIndex` from the first match
   const start = versionHeader.exec(changelog).index;

--- a/scripts/publish-github-release.js
+++ b/scripts/publish-github-release.js
@@ -16,7 +16,7 @@ async function publishRelease(octokit, { repo }) {
     'utf-8',
   );
 
-  const versionHeader = /^##(?!#)/gm;
+  const versionHeader = /^## \d+\.\d+\.\d+/gm;
 
   // we leverage statefulness of `g` regex here for the second `exec` to start of the `lastIndex` from the first match
   const start = versionHeader.exec(changelog).index;


### PR DESCRIPTION
The previous regex was failing hard here because it has only checked for lines with 2 hashes at the beginning. Which made it to catch those two lines as "version headers":
```
## 0.4.0

### Minor Changes
```

Where the second header here is really not a version header. This made the script calculate an empty `content`.

By using a negative lookahead in this regex I ensure that the third character **is not** a hash so we shouldn't catch any other headers accidentally now.