### PR TITLE
Add support for inspecting via websocket

### DIFF
--- a/.changeset/brave-shoes-flow.md
+++ b/.changeset/brave-shoes-flow.md
@@ -2,4 +2,4 @@
 'xstate-viz-app': minor
 ---
 
-Add support for inspecting via websocket
+You can now inspect via WebSocket. Add the WebSocket server url as a query parameter, for example `https://stately.ai/viz?inspect&server=ws://localhost:3000`

--- a/.changeset/brave-shoes-flow.md
+++ b/.changeset/brave-shoes-flow.md
@@ -1,0 +1,5 @@
+---
+'xstate-viz-app': minor
+---
+
+Add support for inspecting via websocket

--- a/.changeset/brave-shoes-flow.md
+++ b/.changeset/brave-shoes-flow.md
@@ -2,4 +2,4 @@
 'xstate-viz-app': minor
 ---
 
-You can now inspect via WebSocket. Add the WebSocket server url as a query parameter, for example `https://stately.ai/viz?inspect&server=ws://localhost:3000`
+You can now inspect via WebSocket. To do that you can add the WebSocket server url as a query parameter, for example `https://stately.ai/viz?inspect&server=ws://localhost:3000`

--- a/src/__tests__/simulationMachine.test.ts
+++ b/src/__tests__/simulationMachine.test.ts
@@ -1,0 +1,21 @@
+import { simulationMachine } from '../simulationMachine';
+
+describe('simulationMachine', () => {
+  describe('UrlSearchParams', () => {
+    describe('with no search params', () => {
+      it.todo('goes to state "visualizing"');
+    });
+    describe('with /viz?inspect', () => {
+      it.todo('goes to state { inspecting: "window" }');
+      it.todo('creates a window receiver');
+    });
+    describe('with /viz?inspect&server=localhost:8080', () => {
+      it.todo('goes to state { inspecting: "websocket" }');
+      it.todo('creates a websocket receiver');
+    });
+    describe('with /viz?inspect&server=localhost:8080&protocol=wss', () => {
+      it.todo('goes to state { inspecting: "websocket" }');
+      it.todo('creates a wss websocket receiver');
+    });
+  });
+});

--- a/src/__tests__/simulationMachine.test.ts
+++ b/src/__tests__/simulationMachine.test.ts
@@ -20,16 +20,12 @@ describe('simulationMachine', () => {
       });
     });
     describe('with /viz?inspect', () => {
-      it.todo('goes to state { inspecting: "window" }');
+      it.todo('goes to state "inspecting"');
       it.todo('creates a window receiver');
     });
-    describe('with /viz?inspect&server=localhost:8080', () => {
-      it.todo('goes to state { inspecting: "websocket" }');
+    describe('with /viz?inspect&server=ws://localhost:8080', () => {
+      it.todo('goes to state "inspecting"');
       it.todo('creates a websocket receiver');
-    });
-    describe('with /viz?inspect&server=localhost:8080&protocol=wss', () => {
-      it.todo('goes to state { inspecting: "websocket" }');
-      it.todo('creates a wss websocket receiver');
     });
   });
 });

--- a/src/__tests__/simulationMachine.test.ts
+++ b/src/__tests__/simulationMachine.test.ts
@@ -1,9 +1,23 @@
+import { interpret } from 'xstate';
 import { simulationMachine } from '../simulationMachine';
 
 describe('simulationMachine', () => {
+  const service = interpret(simulationMachine);
+  afterEach(() => service.stop());
+
   describe('UrlSearchParams', () => {
+    const paramsGetSpy = jest.spyOn(URLSearchParams.prototype, 'get');
+    const paramsHasSpy = jest.spyOn(URLSearchParams.prototype, 'has');
+
     describe('with no search params', () => {
-      it.todo('goes to state "visualizing"');
+      it('goes to state "visualizing"', () => {
+        paramsGetSpy.mockReturnValue(null);
+        paramsHasSpy.mockReturnValue(false);
+
+        service.start();
+
+        expect(service.getSnapshot().matches('visualizing')).toBe(true);
+      });
     });
     describe('with /viz?inspect', () => {
       it.todo('goes to state { inspecting: "window" }');

--- a/src/simulationMachine.tsx
+++ b/src/simulationMachine.tsx
@@ -107,9 +107,11 @@ export const simulationMachine = simModel.createMachine(
     states: {
       inspecting: {
         tags: 'inspecting',
-        initial: new URLSearchParams(window.location.search).has('server')
-          ? 'websocket'
-          : 'window',
+        initial:
+          isOnClientSide() &&
+          new URLSearchParams(window.location.search).has('server')
+            ? 'websocket'
+            : 'window',
         states: {
           websocket: {
             invoke: {

--- a/src/simulationMachine.tsx
+++ b/src/simulationMachine.tsx
@@ -71,7 +71,7 @@ export const simulationMachine = simModel.createMachine(
       new URLSearchParams(window.location.search).has('inspect')
         ? 'inspecting'
         : 'visualizing',
-    entry: [assign({ notifRef: () => spawn(notifMachine) })],
+    entry: assign({ notifRef: () => spawn(notifMachine) }),
     invoke: {
       src: () => (sendBack) => {
         devTools.onRegister((service) => {
@@ -114,15 +114,15 @@ export const simulationMachine = simModel.createMachine(
               'server',
             );
 
-            let receiverRef: InspectReceiver;
+            let receiver: InspectReceiver;
             if (serverUrl) {
               const [protocol, ...server] = serverUrl.split('://');
-              receiverRef = createWebSocketReceiver({
+              receiver = createWebSocketReceiver({
                 protocol: protocol as 'ws' | 'wss',
                 server: server.join('://'),
               });
             } else {
-              receiverRef = createWindowReceiver({
+              receiver = createWindowReceiver({
                 // for some random reason the `window.top` is being rewritten to `window.self`
                 // looks like maybe some webpack replacement plugin (or similar) plays tricks on us
                 // this breaks the auto-detection of the correct `targetWindow` in the `createWindowReceiver`
@@ -133,7 +133,7 @@ export const simulationMachine = simModel.createMachine(
 
             onReceive((event) => {
               if (event.type === 'xstate.event') {
-                receiverRef.send({
+                receiver.send({
                   ...event,
                   type: 'xstate.event',
                   event: JSON.stringify(event.event),
@@ -141,7 +141,7 @@ export const simulationMachine = simModel.createMachine(
               }
             });
 
-            return receiverRef.subscribe((event) => {
+            return receiver.subscribe((event) => {
               switch (event.type) {
                 case 'service.register':
                   let state = event.machine.resolveState(event.state);


### PR DESCRIPTION
Based on discussion #191, this PR adds support for inspecting via websocket. Note the new nested states in `inspecting` called `websocket` and `window`.

New queries have been added to the query string that reflect the parameters for `createWebSocketReceiver`. `server` is required and `protocol` is optional (default is `"ws"`).

```url
http://localhost:3000/viz?inspect&server=localhost:8888
http://localhost:3000/viz?inspect&server=localhost:8888&protocol=ws
```

~~The event handlers in `inspecting` in the invoked `proxy` service are duplicated. Not sure how dry you want this, but we could pull them out into the module scope inside a function.~~ I've moved the inspect receiver into context to avoid duplicating receiver event handlers. Not sure if this is a problem, maybe someone can suggest a better strategy?

This functionality depends on a PR for `@xstate/inspect`: https://github.com/statelyai/xstate/pull/2728 Without that PR, this doesn't work on the server side (in my use case, at least).

![image](https://user-images.githubusercontent.com/23390212/136837431-c295a34d-ae82-4bf5-b53c-effe386263ba.png)

