### PR TITLE
Fix wrong type acquisition URL

### DIFF
--- a/src/typeAcquisition.ts
+++ b/src/typeAcquisition.ts
@@ -139,7 +139,10 @@ const mapModuleNameToModule = (name: string) => {
 };
 
 //** A really simple version of path.resolve */
-const mapRelativePath = (moduleDeclaration: string, currentPath: string) => {
+const mapRelativePath = (
+  moduleDeclaration: string,
+  currentPath: string,
+): string => {
   // https://stackoverflow.com/questions/14780350/convert-relative-path-to-absolute-using-javascript
   function absolute(base: string, relative: string) {
     if (!base) return relative;
@@ -155,6 +158,7 @@ const mapRelativePath = (moduleDeclaration: string, currentPath: string) => {
       if (parts[i] == '..') stack.pop();
       else stack.push(parts[i]);
     }
+
     return stack.join('/');
   }
 
@@ -569,7 +573,11 @@ const getDependenciesForModule = (
           throw `No outer module or path for a relative import: ${moduleToDownload}`;
         }
 
-        const absolutePathForModule = mapRelativePath(moduleToDownload, path);
+        let absolutePathForModule = mapRelativePath(moduleToDownload, path);
+
+        if (moduleToDownload === '.') {
+          absolutePathForModule += '/index';
+        }
 
         // So it doesn't run twice for a package
         acquiredTypeDefs[moduleID] = null;

--- a/src/typeAcquisition.ts
+++ b/src/typeAcquisition.ts
@@ -575,6 +575,8 @@ const getDependenciesForModule = (
 
         let absolutePathForModule = mapRelativePath(moduleToDownload, path);
 
+        // patch the broken logic from the original `typeAcquisition`
+        // TODO: replace the whole thing with `@typescript/ata` that has been published since our "fork" was created
         if (moduleToDownload === '.') {
           absolutePathForModule += '/index';
         }


### PR DESCRIPTION
This PR fixes this issue:

<img width="719" alt="CleanShot 2021-11-18 at 00 02 56@2x" src="https://user-images.githubusercontent.com/1093738/142355170-fc8a727d-831e-4d48-b3de-088e4d0db10c.png">

Probably not the best fix, but it works. 