### PR TITLE
Only show controls when control=1

### DIFF
--- a/src/CanvasView.tsx
+++ b/src/CanvasView.tsx
@@ -69,6 +69,8 @@ export const CanvasView: React.FC = () => {
 
   const canShowWelcomeMessage = sourceState.hasTag('canShowWelcomeMessage');
 
+  const showControls = useMemo(() => !embed?.isEmbedded || embed.controls, [embed])
+
   const showZoomButtonsInEmbed = useMemo(
     () => !embed?.isEmbedded || (embed.controls && embed.zoom),
     [embed],
@@ -104,7 +106,7 @@ export const CanvasView: React.FC = () => {
         {isEmpty && canShowWelcomeMessage && <WelcomeArea />}
       </CanvasContainer>
 
-      <Box
+      {showControls && <Box
         display="flex"
         flexDirection="row"
         alignItems="center"
@@ -223,7 +225,7 @@ export const CanvasView: React.FC = () => {
             </Portal>
           </Menu>
         )}
-      </Box>
+      </Box>}
     </Box>
   );
 };


### PR DESCRIPTION
This PR fixes a bug that was created in https://github.com/statelyai/xstate-viz/pull/315 where RESET and Fit to content buttons were shown all the time in embed mode. The fix here makes sure they're shown only if `controls=1` is available.

![image](https://user-images.githubusercontent.com/8332043/142403447-e799eb73-6b38-4f7f-9a1f-d4a542b16c8e.png)
