### PR TITLE
Remove compaction on root node. Fixes #279

### DIFF
--- a/.changeset/stupid-cherries-talk.md
+++ b/.changeset/stupid-cherries-talk.md
@@ -1,0 +1,20 @@
+---
+'xstate-viz-app': patch
+---
+
+Self-transitions on the machine will no longer cause graph layout to fail:
+
+```js
+import { createMachine } from 'xstate';
+
+const machine = createMachine({
+  on: {
+    // These will now display as expected
+    LOAD: {},
+    UPDATE: {},
+  },
+  states: {
+    something: {},
+  },
+});
+```

--- a/cypress/integration/layout.spec.ts
+++ b/cypress/integration/layout.spec.ts
@@ -1,0 +1,29 @@
+describe('Graph layout', () => {
+  it('layout should not fail with self transitions on machine node', () => {
+    // Plant a fake entry in localStorage
+    cy.setLocalStorage(
+      'xstate_viz_raw_source|no_source',
+      JSON.stringify({
+        date: new Date(),
+        sourceRawContent: `
+import { createMachine } from 'xstate';
+const machine = createMachine({
+  on: {
+    // These will now display as expected
+    LOAD: {},
+    UPDATE: {},
+  },
+  states: {
+    something: {},
+  },
+});
+`,
+      }),
+    );
+
+    cy.visit('/viz');
+
+    // Will time out if visualization fails
+    cy.getCanvas();
+  });
+});

--- a/src/graphUtils.ts
+++ b/src/graphUtils.ts
@@ -24,16 +24,6 @@ if (typeof ELK !== 'undefined') {
   elk = new ELK();
 }
 
-const rootLayoutOptions: LayoutOptions = {
-  'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
-  'elk.algorithm': 'layered',
-  'elk.layered.considerModelOrder': 'NODES_AND_EDGES',
-  'elk.layered.wrapping.strategy': 'MULTI_EDGE',
-  'elk.layered.compaction.postCompaction.strategy': 'LEFT',
-  'elk.aspectRatio': '2',
-  'elk.direction': 'RIGHT',
-};
-
 type RelativeNodeEdgeMap = [
   Map<StateNode | undefined, DirectedGraphEdge[]>,
   Map<string, StateNode | undefined>,
@@ -298,7 +288,7 @@ export function isStateElkNode(node: ElkNode): node is StateElkNode {
   return 'absolutePosition' in node;
 }
 
-function elkJSON(elkNode: StateElkNode): any {
+function elkJSON(elkNode: ElkNode): any {
   const { id, layoutOptions, width, height, children, edges, ports } = elkNode;
 
   return {
@@ -312,7 +302,9 @@ function elkJSON(elkNode: StateElkNode): any {
       width: port.width,
       height: port.height,
     })),
-    edges: edges.map((edge) => {
+    edges: edges?.map((_edge) => {
+      const edge = _edge as ElkExtendedEdge;
+
       return {
         id: getElkId(edge.id),
         labels: edge.labels?.map((label) => ({
@@ -349,7 +341,14 @@ export async function getElkGraph(
     id: 'root',
     edges: rootEdges.map((edge) => getElkEdge(edge, rectMap)),
     children: [getElkChild(rootDigraphNode, runContext)],
-    layoutOptions: rootLayoutOptions,
+    layoutOptions: {
+      'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
+      'elk.algorithm': 'layered',
+      'elk.layered.considerModelOrder': 'NODES_AND_EDGES',
+      'elk.layered.wrapping.strategy': 'MULTI_EDGE',
+      'elk.aspectRatio': '2',
+      'elk.direction': 'RIGHT',
+    },
   });
 
   let rootElkNode: ElkNode | undefined = undefined;


### PR DESCRIPTION
This PR removes compaction on the root node, which was causing ELK to fail with self-transitions on the machine.

<img width="887" alt="CleanShot 2022-01-09 at 06 31 09@2x" src="https://user-images.githubusercontent.com/1093738/148684329-7f3858cd-4650-41ba-a1aa-410b6078483d.png">
