### PR TITLE
Strip unecessary permissions from generated embed iframe html

### DIFF
--- a/.changeset/chatty-peas-bake.md
+++ b/.changeset/chatty-peas-bake.md
@@ -1,0 +1,5 @@
+---
+'xstate-viz-app': patch
+---
+
+Remove unecessary feature policy claims from generated embed iframes

--- a/cypress/integration/embed-preview.spec.ts
+++ b/cypress/integration/embed-preview.spec.ts
@@ -39,7 +39,7 @@ describe('Embed Preview', () => {
     cy.findByRole('menuitem', { name: /embed/i }).should('be.visible');
   });
 
-  it('Clicking on the Embed button opens the Embed preview', () => {
+  it('Opens the Embed preview when clicking on the Embed button', () => {
     cy.findByRole('button', { name: /share/i }).click();
     cy.findByRole('menuitem', { name: /embed/i }).click();
     cy.getEmbedPreview().should('be.visible');

--- a/src/EmbedPreview.tsx
+++ b/src/EmbedPreview.tsx
@@ -56,10 +56,10 @@ const extractFormData = (form: HTMLFormElement): ParsedEmbed => {
   return paramsToRecord(data);
 };
 
-const getEmbedCodeFromUrl = (embedUrl: string) => `<iframe src="${embedUrl}"
-allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
-></iframe>`;
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
+ */
+const getEmbedCodeFromUrl = (embedUrl: string) => `<iframe src="${embedUrl}" sandbox="allow-same-origin allow-scripts"></iframe>`;
 
 const embedPreviewModel = createModel(
   {


### PR DESCRIPTION
As noted in the ticket, the feature policy on the iframe generated by the "Share > Embed" button are far too liberal.

This removes all entries from the feature policy as none seem necessary and restricts sandbox restrictions to a reasonable level.

Closes #285 