### PR TITLE
Fixed panning/dragging interations (the ones that include pressing pointer down) in FireFox

### DIFF
--- a/.changeset/healthy-lies-jump.md
+++ b/.changeset/healthy-lies-jump.md
@@ -1,0 +1,5 @@
+---
+'xstate-viz-app': patch
+---
+
+Fixed panning/dragging interations (the ones that include pressing pointer down) in FireFox.

--- a/src/dragSessionTracker.ts
+++ b/src/dragSessionTracker.ts
@@ -141,7 +141,7 @@ export const dragSessionTracker = dragSessionModel.createMachine(
         ref!.current!.releasePointerCapture(session!.pointerId),
       setSessionData: assign({
         session: (ctx, ev: any) => {
-          if (ev.pointerId && ev.point)
+          if ('pointerId' in ev && ev.point)
             return {
               pointerId: ev.pointerId,
               point: ev.point,


### PR DESCRIPTION
https://github.com/statelyai/xstate-viz/issues/342

FF is using 0 as `pointerId` for the primary pointer so naturally this didn't pass the truthiness check here. Other browsers worked as they are using 1.