### PR TITLE
Fix simulating events on child actors. #326

### DIFF
--- a/src/simulationMachine.tsx
+++ b/src/simulationMachine.tsx
@@ -14,6 +14,7 @@ import { devTools } from './devInterface';
 import { notifMachine } from './notificationMachine';
 import { AnyState, AnyStateMachine, ServiceData } from './types';
 import { isOnClientSide } from './isOnClientSide';
+import { findChildService } from './utils';
 
 export interface SimEvent extends SCXML.Event<any> {
   timestamp: number;
@@ -180,7 +181,7 @@ export const simulationMachine = simModel.createMachine(
                   }
                 });
               } else if (event.type === 'xstate.event') {
-                const service = serviceMap.get(event.sessionId);
+                const service = serviceMap.get(event.sessionId) || findChildService(Array.from(serviceMap.values()), event.sessionId);
                 if (service) {
                   try {
                     service.send(event.event);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,9 @@ import * as React from 'react';
 import {
   ActionObject,
   ActionTypes,
+  ActorRef,
   AnyEventObject,
+  AnyInterpreter,
   CancelAction,
   Interpreter,
   SendAction,
@@ -429,3 +431,21 @@ export const isAcceptingSpaceNatively = (
   el.tagName === 'INPUT' ||
   isTextInputLikeElement(el) ||
   getRoles(el).includes('button');
+
+export const findChildService = (services: ActorRef<any>[], sessionId: string, maxDepth = 100): AnyInterpreter | undefined => {
+  return services.reduce<AnyInterpreter | undefined>((prev, child) => {
+    if (maxDepth === 0) {
+      return prev
+    }
+    if (prev) {
+      return prev
+    }
+    if (child instanceof Interpreter) {
+      if (child.sessionId === sessionId) {
+        return child
+      }
+      return findChildService(Array.from(child.children.values()), sessionId, maxDepth - 1)
+    }
+    return undefined
+  }, undefined)
+} 


### PR DESCRIPTION
This PR fixes #326 by searching for child actors when simulating events:

- adds method `findChildService` to `src/utils.ts` to recursively search for child service with the target `sessionId`
- start the search for child services if no root service matches the `sessionId` of the even to process