### PR TITLE
fix #324: add ctrl + space as shortcut into the SettingsPanel

### DIFF
--- a/src/SettingsPanel.tsx
+++ b/src/SettingsPanel.tsx
@@ -82,6 +82,16 @@ const KeyboardShortcuts = () => (
           </Td>
           <Td>Zoom-in/out</Td>
         </Tr>
+        <Tr>
+          <Td>
+            <VStack alignItems="flex-start">
+              <span>
+                <Kbd>Ctrl</Kbd> + <Kbd>Space</Kbd>
+              </span>
+            </VStack>
+          </Td>
+          <Td>Navigate around in pan mode</Td>
+        </Tr>
       </Tbody>
     </Table>
   </Box>


### PR DESCRIPTION
This PR adds a new shortcut to the `SettingsPanel` as suggested in #324. If you prefer the shortcut to appear elsewhere or something about the description doesn't meet your needs, please let me know.