### PR TITLE
The editor will now prefer imports from xstate core

### DIFF
--- a/.changeset/nervous-donkeys-perform.md
+++ b/.changeset/nervous-donkeys-perform.md
@@ -1,0 +1,5 @@
+---
+'xstate-viz-app': patch
+---
+
+The editor will now prefer imports from xstate core.

--- a/cypress/integration/autocomplete.spec.ts
+++ b/cypress/integration/autocomplete.spec.ts
@@ -1,15 +1,3 @@
-const importFromXstate = () => {
-  cy.get('body').then(($body) => {
-    if ($body.text().includes("Auto import from 'xstate'")) {
-      cy.getMonacoEditor().type('{enter}');
-    } else {
-      cy.getMonacoEditor().type('{downarrow}');
-      cy.wait(500);
-      importFromXstate();
-    }
-  });
-};
-
 describe('Autocomplete in the editor', () => {
   it('Should allow you to autocomplete XState imports', () => {
     cy.visit('/viz');
@@ -18,7 +6,7 @@ describe('Autocomplete in the editor', () => {
     // Wait for the autocomplete to show up
     cy.contains('assign');
 
-    importFromXstate();
+    cy.getMonacoEditor().type('{downarrow}{enter}');
 
     cy.contains(`import { assign, createMachine } from 'xstate';`);
   });

--- a/cypress/integration/autocomplete.spec.ts
+++ b/cypress/integration/autocomplete.spec.ts
@@ -6,7 +6,7 @@ describe('Autocomplete in the editor', () => {
     // Wait for the autocomplete to show up
     cy.contains('assign');
 
-    cy.getMonacoEditor().type('{downarrow}{downarrow}{enter}');
+    cy.getMonacoEditor().type('{downarrow}{downarrow}{downarrow}{enter}');
 
     cy.contains(`import { assign, createMachine } from 'xstate';`);
   });

--- a/cypress/integration/autocomplete.spec.ts
+++ b/cypress/integration/autocomplete.spec.ts
@@ -1,3 +1,15 @@
+const importFromXstate = () => {
+  cy.get('body').then(($body) => {
+    if ($body.text().includes("Auto import from 'xstate'")) {
+      cy.getMonacoEditor().type('{enter}');
+    } else {
+      cy.getMonacoEditor().type('{downarrow}');
+      cy.wait(500);
+      importFromXstate();
+    }
+  });
+};
+
 describe('Autocomplete in the editor', () => {
   it('Should allow you to autocomplete XState imports', () => {
     cy.visit('/viz');
@@ -6,7 +18,7 @@ describe('Autocomplete in the editor', () => {
     // Wait for the autocomplete to show up
     cy.contains('assign');
 
-    cy.getMonacoEditor().type('{downarrow}{downarrow}{downarrow}{enter}');
+    importFromXstate();
 
     cy.contains(`import { assign, createMachine } from 'xstate';`);
   });

--- a/src/monacoPatch.ts
+++ b/src/monacoPatch.ts
@@ -208,43 +208,54 @@ monacoLoader.init = function (...args) {
             return;
           }
 
-          const suggestions = info.entries.map((entry: any) => {
-            let range = wordRange;
-            if (entry.replacementSpan) {
-              const p1 = model.getPositionAt(entry.replacementSpan.start);
-              const p2 = model.getPositionAt(
-                entry.replacementSpan.start + entry.replacementSpan.length,
-              );
+          const suggestions = info.entries
+            .filter((entry: any) => {
+              // Here we filter any entry that exists in XState but is not imported from the core library
+              if (
+                entry.name in XState &&
+                entry.source !== 'file:///node_modules/xstate/lib/index'
+              ) {
+                return false;
+              }
+              return true;
+            })
+            .map((entry: any) => {
+              let range = wordRange;
+              if (entry.replacementSpan) {
+                const p1 = model.getPositionAt(entry.replacementSpan.start);
+                const p2 = model.getPositionAt(
+                  entry.replacementSpan.start + entry.replacementSpan.length,
+                );
 
-              range = new monaco.Range(
-                p1.lineNumber,
-                p1.column,
-                p2.lineNumber,
-                p2.column,
-              );
-            }
+                range = new monaco.Range(
+                  p1.lineNumber,
+                  p1.column,
+                  p2.lineNumber,
+                  p2.column,
+                );
+              }
 
-            const tags = [];
-            if (entry.kindModifiers?.indexOf('deprecated') !== -1) {
-              tags.push(monaco.languages.CompletionItemTag.Deprecated);
-            }
+              const tags = [];
+              if (entry.kindModifiers?.indexOf('deprecated') !== -1) {
+                tags.push(monaco.languages.CompletionItemTag.Deprecated);
+              }
 
-            return {
-              uri: resource,
-              position: position,
-              offset: offset,
-              range: range,
-              label: entry.name,
-              insertText: entry.name,
-              sortText: entry.sortText,
-              kind: (provider.constructor as any).convertKind(entry.kind),
-              tags,
-              // properties below were added here
-              data: entry.data,
-              source: entry.source,
-              hasAction: entry.hasAction,
-            };
-          });
+              return {
+                uri: resource,
+                position: position,
+                offset: offset,
+                range: range,
+                label: entry.name,
+                insertText: entry.name,
+                sortText: entry.sortText,
+                kind: (provider.constructor as any).convertKind(entry.kind),
+                tags,
+                // properties below were added here
+                data: entry.data,
+                source: entry.source,
+                hasAction: entry.hasAction,
+              };
+            });
 
           return {
             suggestions,

--- a/src/monacoPatch.ts
+++ b/src/monacoPatch.ts
@@ -4,8 +4,8 @@ import type { languages } from 'monaco-editor';
 
 // should be in sync with the "modules" allowed by our eval Function
 import * as XState from 'xstate';
-import * as XStateActions from 'xstate/lib/actions';
 import * as XStateModel from 'xstate/lib/model';
+import * as XStateActions from 'xstate/lib/actions';
 
 // dont hate the player, hate the game
 // https://github.com/microsoft/vscode-loader/issues/33
@@ -123,26 +123,12 @@ function getAutoImport(provider: any, details: any): AutoImport | undefined {
   let specifier = '';
 
   // fortunately auto-imports are not suggested for types
-  if (
-    codeAction.description.includes('xstate/lib/actions') &&
-    details.name in XStateActions
-  ) {
-    specifier = 'xstate/lib/actions';
-  } else if (
-    codeAction.description.includes('xstate/lib/actionTypes') &&
-    details.name in XStateActions
-  ) {
-    specifier = 'xstate/lib/actionTypes';
-  } else if (
-    codeAction.description.includes('xstate/lib/model') &&
-    details.name in XStateModel
-  ) {
-    specifier = 'xstate/lib/model';
-  } else if (
-    codeAction.description.includes('xstate') &&
-    details.name in XState
-  ) {
+  if (details.name in XState) {
     specifier = 'xstate';
+  } else if (details.name in XStateModel) {
+    specifier = 'xstate/lib/model';
+  } else if (details.name in XStateActions) {
+    specifier = 'xstate/lib/actions';
   }
 
   if (!specifier) {

--- a/src/monacoPatch.ts
+++ b/src/monacoPatch.ts
@@ -4,8 +4,8 @@ import type { languages } from 'monaco-editor';
 
 // should be in sync with the "modules" allowed by our eval Function
 import * as XState from 'xstate';
-import * as XStateModel from 'xstate/lib/model';
 import * as XStateActions from 'xstate/lib/actions';
+import * as XStateModel from 'xstate/lib/model';
 
 // dont hate the player, hate the game
 // https://github.com/microsoft/vscode-loader/issues/33
@@ -123,12 +123,26 @@ function getAutoImport(provider: any, details: any): AutoImport | undefined {
   let specifier = '';
 
   // fortunately auto-imports are not suggested for types
-  if (details.name in XState) {
-    specifier = 'xstate';
-  } else if (details.name in XStateModel) {
-    specifier = 'xstate/lib/model';
-  } else if (details.name in XStateActions) {
+  if (
+    codeAction.description.includes('xstate/lib/actions') &&
+    details.name in XStateActions
+  ) {
     specifier = 'xstate/lib/actions';
+  } else if (
+    codeAction.description.includes('xstate/lib/actionTypes') &&
+    details.name in XStateActions
+  ) {
+    specifier = 'xstate/lib/actionTypes';
+  } else if (
+    codeAction.description.includes('xstate/lib/model') &&
+    details.name in XStateModel
+  ) {
+    specifier = 'xstate/lib/model';
+  } else if (
+    codeAction.description.includes('xstate') &&
+    details.name in XState
+  ) {
+    specifier = 'xstate';
   }
 
   if (!specifier) {


### PR DESCRIPTION
The autocomplete test for importing assign from xstate has been updated to support picking the new placement of assign in the autocomplete menu. The assign we want is now number three in the list, was number two before.

Update: hmm 🤔 it looks like our Cypress test suite here is unreliable. It's now failed three times, for three different reasons. This isolated change should be fine, but I guess we need another issue around getting these tests more stable.